### PR TITLE
Remove locks for env as they are not necessary

### DIFF
--- a/include/nitro/env/get.hpp
+++ b/include/nitro/env/get.hpp
@@ -31,7 +31,6 @@
 
 #include <cstdlib>
 #include <string>
-#include <thread>
 
 namespace nitro
 {

--- a/include/nitro/env/get.hpp
+++ b/include/nitro/env/get.hpp
@@ -30,7 +30,6 @@
 #define INCLUDE_NITRO_ENV_GET_HPP
 
 #include <cstdlib>
-#include <mutex>
 #include <string>
 #include <thread>
 
@@ -40,11 +39,7 @@ namespace env
 {
     inline std::string get(std::string name, std::string default_ = "")
     {
-        static std::mutex getenv_mutex;
-
-        std::lock_guard<std::mutex> my_lock(getenv_mutex);
-
-        char* tmp = getenv(name.c_str());
+        char* tmp = std::getenv(name.c_str());
 
         if (tmp == nullptr)
         {


### PR DESCRIPTION
According to http://en.cppreference.com/w/cpp/utility/program/getenv getenv is threadsave since c++11