### PR TITLE
Changes the build script to modern CMake

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -139,12 +139,9 @@ matrix:
       osx_image: xcode7.3
     - os: osx
       osx_image: xcode8
-jobs:
-  include:
-    - stage: configure
-      script: cmake --version
-    - script: cmake .
-    - stage: build
-      script: make
-    - stage: test
-      script: ctest -v .
+-before_script:
+  - cmake --version
+  - cmake .
+-script:
+  - make
+  - ctest -V .

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ matrix:
             - cmake-data
           sources: &sources
             - ubuntu-toolchain-r-test
-            - debian-sid
+            - george-edison55-precise-backports
     - os: linux
       env: CXX="g++-5" CC="gcc-5"
       compiler: gcc
@@ -64,7 +64,7 @@ matrix:
           sources:
             - llvm-toolchain-precise-3.6
             - ubuntu-toolchain-r-test
-            - debian-sid
+            - george-edison55-precise-backports
     - os: linux
       env: CXX="clang++-3.7" CC="clang-3.7"
       compiler: clang
@@ -78,7 +78,7 @@ matrix:
           sources:
             - llvm-toolchain-precise-3.7
             - ubuntu-toolchain-r-test
-            - debian-sid
+            - george-edison55-precise-backports
     - os: linux
       env: CXX="clang++-3.8" CC="clang-3.8"
       compiler: clang
@@ -92,7 +92,7 @@ matrix:
           sources:
             - llvm-toolchain-precise-3.8
             - ubuntu-toolchain-r-test
-            - debian-sid
+            - george-edison55-precise-backports
     - os: linux
       env: CXX="clang++-3.9" CC="clang-3.9"
       compiler: clang
@@ -106,7 +106,7 @@ matrix:
           sources:
             - llvm-toolchain-trusty-3.9
             - ubuntu-toolchain-r-test
-            - debian-sid
+            - george-edison55-precise-backports
     - os: linux
       env: CXX="clang++-4.0" CC="clang-4.0"
       compiler: clang
@@ -120,7 +120,7 @@ matrix:
           sources:
             - llvm-toolchain-trusty-4.0
             - ubuntu-toolchain-r-test
-            - debian-sid
+            - george-edison55-precise-backports
     - os: linux
       env: CXX="clang++-5.0" CC="clang-5.0"
       compiler: clang
@@ -134,14 +134,17 @@ matrix:
           sources:
             - llvm-toolchain-trusty
             - ubuntu-toolchain-r-test
-            - debian-sid
+            - george-edison55-precise-backports
     - os: osx
       osx_image: xcode7.3
     - os: osx
       osx_image: xcode8
-before_script:
-  - cmake --version
-  - cmake .
-script:
-  - make
-  - ctest -V .
+jobs:
+  include:
+    - stage: configure
+      script: cmake --version
+    - script: cmake .
+    - stage: build
+      script: make
+    - stage: test
+      script: ctest -v .

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: generic
 
-sudo: required
-dist: precise
+sudo: false
+dist: trusty
 
 matrix:
   include:
@@ -17,7 +17,7 @@ matrix:
             - cmake-data
           sources: &sources
             - ubuntu-toolchain-r-test
-            - george-edison55-precise-backports
+            - debian-sid
     - os: linux
       env: CXX="g++-5" CC="gcc-5"
       compiler: gcc
@@ -41,6 +41,17 @@ matrix:
             - cmake-data
           sources: *sources
     - os: linux
+      env: CXX="g++-7" CC="gcc-7"
+      compiler: gcc
+      addons:
+        apt:
+          packages:
+            - gcc-7
+            - g++-7
+            - cmake
+            - cmake-data
+          sources: *sources
+    - os: linux
       env: CXX="clang++-3.6" CC="clang-3.6"
       compiler: clang
       addons:
@@ -53,7 +64,7 @@ matrix:
           sources:
             - llvm-toolchain-precise-3.6
             - ubuntu-toolchain-r-test
-            - george-edison55-precise-backports
+            - debian-sid
     - os: linux
       env: CXX="clang++-3.7" CC="clang-3.7"
       compiler: clang
@@ -67,7 +78,7 @@ matrix:
           sources:
             - llvm-toolchain-precise-3.7
             - ubuntu-toolchain-r-test
-            - george-edison55-precise-backports
+            - debian-sid
     - os: linux
       env: CXX="clang++-3.8" CC="clang-3.8"
       compiler: clang
@@ -81,7 +92,7 @@ matrix:
           sources:
             - llvm-toolchain-precise-3.8
             - ubuntu-toolchain-r-test
-            - george-edison55-precise-backports
+            - debian-sid
     - os: linux
       env: CXX="clang++-3.9" CC="clang-3.9"
       compiler: clang
@@ -93,9 +104,23 @@ matrix:
             - cmake
             - cmake-data
           sources:
-            - llvm-toolchain-precise-3.9
+            - llvm-toolchain-trusty-3.9
             - ubuntu-toolchain-r-test
-            - george-edison55-precise-backports
+            - debian-sid
+    - os: linux
+      env: CXX="clang++-4.0" CC="clang-4.0"
+      compiler: clang
+      addons:
+        apt:
+          packages:
+            - clang-4.0
+            - g++-5
+            - cmake
+            - cmake-data
+          sources:
+            - llvm-toolchain-trusty-4.0
+            - ubuntu-toolchain-r-test
+            - debian-sid
     - os: linux
       env: CXX="clang++-5.0" CC="clang-5.0"
       compiler: clang
@@ -107,9 +132,9 @@ matrix:
             - cmake
             - cmake-data
           sources:
-            - llvm-toolchain-precise
+            - llvm-toolchain-trusty
             - ubuntu-toolchain-r-test
-            - george-edison55-precise-backports
+            - debian-sid
     - os: osx
       osx_image: xcode7.3
     - os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -139,9 +139,9 @@ matrix:
       osx_image: xcode7.3
     - os: osx
       osx_image: xcode8
-- before_script:
+before_script:
   - cmake --version
   - cmake .
-- script:
+script:
   - make
   - ctest -V .

--- a/.travis.yml
+++ b/.travis.yml
@@ -139,9 +139,9 @@ matrix:
       osx_image: xcode7.3
     - os: osx
       osx_image: xcode8
--before_script:
+- before_script:
   - cmake --version
   - cmake .
--script:
+- script:
   - make
   - ctest -V .

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,7 +99,6 @@ target_compile_features(NitroCore
         cxx_thread_local
         cxx_trailing_return_types
         cxx_user_literals
-        cxx_variable_templates
         cxx_variadic_templates
         cxx_template_template_parameters
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,7 +96,6 @@ target_compile_features(NitroCore
         cxx_range_for
         cxx_return_type_deduction
         cxx_rvalue_references
-        cxx_thread_local
         cxx_trailing_return_types
         cxx_user_literals
         cxx_variadic_templates

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2016, Technische Universität Dresden, Germany
+# Copyright (c) 2016-2017, Technische Universität Dresden, Germany
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without modification, are permitted
@@ -25,7 +25,7 @@
 
 project(Nitro)
 
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.2)
 
 # Intialize git submodules if not done already
 file(GLOB SUBMODULE_FILES "common/*")
@@ -76,7 +76,32 @@ target_include_directories(NitroCore INTERFACE
 )
 target_compile_features(NitroCore
     INTERFACE
-        cxx_std_14
+        cxx_auto_type
+        cxx_constexpr
+        cxx_decltype
+        cxx_decltype_auto
+        cxx_defaulted_functions
+        cxx_defaulted_move_initializers
+        cxx_delegating_constructors
+        cxx_deleted_functions
+        cxx_explicit_conversions
+        cxx_generalized_initializers
+        cxx_generic_lambdas
+        cxx_inheriting_constructors
+        cxx_lambdas
+        cxx_lambda_init_captures
+        cxx_noexcept
+        cxx_nullptr
+        cxx_override
+        cxx_range_for
+        cxx_return_type_deduction
+        cxx_rvalue_references
+        cxx_thread_local
+        cxx_trailing_return_types
+        cxx_user_literals
+        cxx_variable_templates
+        cxx_variadic_templates
+        cxx_template_template_parameters
 )
 
 add_library(NitroDl INTERFACE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,9 +23,9 @@
 # IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
 # THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-project(NitroCXXLibraries)
+project(Nitro)
 
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.3)
 
 # Intialize git submodules if not done already
 file(GLOB SUBMODULE_FILES "common/*")
@@ -40,10 +40,96 @@ endif()
 
 include(common/DefaultBuildType.cmake)
 
-include(Nitro.cmake)
+# Intialize git submodules if not done already
+file(GLOB SUBMODULE_FILES "${CMAKE_CURRENT_LIST_DIR}/common/*")
+list(LENGTH SUBMODULE_FILES COUNT_COMMON)
 
-SET(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wall -Wextra -pedantic")
+if(${COUNT_COMMON} EQUAL 0)
+    message(STATUS "Initializing git submodule")
+    execute_process(COMMAND "git" "submodule" "init" WORKING_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}")
+endif()
+message(STATUS "Updating git submodule")
+execute_process(COMMAND "git" "submodule" "update" WORKING_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}")
 
+include(${CMAKE_CURRENT_LIST_DIR}/common/UnsetIfUpdated.cmake)
+UnsetIfUpdated(MIN_LOG_LEVEL CMAKE_BUILD_TYPE)
+
+if (NOT MIN_LOG_LEVEL)
+    if (CMAKE_BUILD_TYPE STREQUAL "Debug")
+        set(MIN_LOG_LEVEL "trace" CACHE STRING
+                "The minimum required severity level of log messages to be compiled into the binary.")
+    else()
+        set(MIN_LOG_LEVEL "debug" CACHE STRING
+                "The minimum required severity level of log messages to be compiled into the binary.")
+    endif()
+
+    set_property(CACHE MIN_LOG_LEVEL PROPERTY "STRINGS" "fatal" "error" "warn" "info" "debug"
+            "trace")
+endif()
+
+set(Nitro_VERSION 1.0)
+
+add_library(NitroCore INTERFACE)
+target_include_directories(NitroCore INTERFACE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
+)
+target_compile_features(NitroCore
+    INTERFACE
+        cxx_std_14
+)
+
+add_library(NitroDl INTERFACE)
+target_link_libraries(NitroDl
+    INTERFACE
+        Nitro::Core
+        ${CMAKE_DL_LIBS}
+)
+
+add_library(NitroLog INTERFACE)
+target_link_libraries(NitroLog
+    INTERFACE
+        Nitro::Core
+)
+target_compile_definitions(NitroLog INTERFACE NITRO_LOG_MIN_SEVERITY=${MIN_LOG_LEVEL})
+
+add_library(NitroAll INTERFACE)
+target_link_libraries(NitroAll
+    INTERFACE
+        Nitro::Core
+        Nitro::Log
+        Nitro::Dl
+)
+
+add_library(Nitro::Nitro ALIAS NitroAll)
+add_library(Nitro::Core ALIAS NitroCore)
+add_library(Nitro::Dl ALIAS NitroDl)
+add_library(Nitro::Log ALIAS NitroLog)
+
+install(DIRECTORY
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/nitro
+    DESTINATION include
+)
+install(TARGETS NitroCore NitroAll NitroDl NitroLog EXPORT NitroTargets
+    LIBRARY DESTINATION lib
+    ARCHIVE DESTINATION lib
+    RUNTIME DESTINATION bin
+    INCLUDES DESTINATION include
+)
+install(EXPORT NitroTargets
+    FILE NitroTargets.cmake
+    NAMESPACE Nitro::
+    DESTINATION lib/cmake/Nitro
+)
+
+include(CMakePackageConfigHelpers)
+write_basic_package_version_File("NitroConfigVersion.cmake"
+    VERSION ${Nitro_VERSION}
+    COMPATIBILITY SameMajorVersion
+)
+install(FILES "NitroConfig.cmake" "${CMAKE_CURRENT_BINARY_DIR}/NitroConfigVersion.cmake"
+    DESTINATION lib/cmake/Nitro
+)
 
 include(CTest)
 

--- a/Nitro.cmake
+++ b/Nitro.cmake
@@ -58,3 +58,5 @@ SET(CMAKE_CXX_STANDARD 14)
 SET(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 include_directories(${CMAKE_CURRENT_LIST_DIR}/include)
+
+message(DEPRECATION "To use include(.../Nitro.cmake) is deprecated. Please just use find_package(Nitro REQUIRED). Be modern. Shoot yourself left-handed.")

--- a/NitroConfig.cmake
+++ b/NitroConfig.cmake
@@ -1,0 +1,1 @@
+include("${CMAKE_CURRENT_LIST_DIR}/NitroTargets.cmake")

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,6 +1,8 @@
 macro(NitroTest TEST)
     get_filename_component(TEST_NAME ${TEST} NAME_WE)
 
+    set(TEST_NAME "Nitro.${TEST_NAME}")
+
     add_executable(${TEST_NAME} ${TEST})
     target_link_libraries(${TEST_NAME} Nitro::Core)
     target_compile_options(${TEST_NAME} PRIVATE -Wall -Wextra -pedantic)
@@ -13,11 +15,11 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR}/Catch/include)
 add_library(nitro_test_lib SHARED nitro_test_lib.cpp)
 
 NitroTest(dl_test.cpp)
-set_tests_properties(dl_test PROPERTIES ENVIRONMENT "LD_LIBRARY_PATH=${CMAKE_CURRENT_BINARY_DIR}:$ENV{LD_LIBRARY_PATH}")
-target_link_libraries(dl_test Nitro::Dl)
+set_tests_properties(Nitro.dl_test PROPERTIES ENVIRONMENT "LD_LIBRARY_PATH=${CMAKE_CURRENT_BINARY_DIR}:$ENV{LD_LIBRARY_PATH}")
+target_link_libraries(Nitro.dl_test Nitro::Dl)
 
 NitroTest(env_get_test.cpp)
-set_tests_properties(env_get_test PROPERTIES ENVIRONMENT "TEST_1=THIS_WAS_SET")
+set_tests_properties(Nitro.env_get_test PROPERTIES ENVIRONMENT "TEST_1=THIS_WAS_SET")
 
 NitroTest(broken_options_test.cpp)
 
@@ -28,7 +30,7 @@ NitroTest(reverse_test.cpp)
 NitroTest(enumerate_test.cpp)
 
 NitroTest(logging_test.cpp)
-target_link_libraries(logging_test Nitro::Log)
+target_link_libraries(Nitro.logging_test Nitro::Log)
 
 NitroTest(string_ref_test.cpp)
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2,6 +2,9 @@ macro(NitroTest TEST)
     get_filename_component(TEST_NAME ${TEST} NAME_WE)
 
     add_executable(${TEST_NAME} ${TEST})
+    target_link_libraries(${TEST_NAME} Nitro::Core)
+    target_compile_options(${TEST_NAME} PRIVATE -Wall -Wextra -pedantic)
+
     add_test(${TEST_NAME} ${TEST_NAME})
 endmacro()
 
@@ -11,7 +14,7 @@ add_library(nitro_test_lib SHARED nitro_test_lib.cpp)
 
 NitroTest(dl_test.cpp)
 set_tests_properties(dl_test PROPERTIES ENVIRONMENT "LD_LIBRARY_PATH=${CMAKE_CURRENT_BINARY_DIR}:$ENV{LD_LIBRARY_PATH}")
-target_link_libraries(dl_test ${CMAKE_DL_LIBS})
+target_link_libraries(dl_test Nitro::Dl)
 
 NitroTest(env_get_test.cpp)
 set_tests_properties(env_get_test PROPERTIES ENVIRONMENT "TEST_1=THIS_WAS_SET")
@@ -25,6 +28,7 @@ NitroTest(reverse_test.cpp)
 NitroTest(enumerate_test.cpp)
 
 NitroTest(logging_test.cpp)
+target_link_libraries(logging_test Nitro::Log)
 
 NitroTest(string_ref_test.cpp)
 

--- a/tests/logging_test.cpp
+++ b/tests/logging_test.cpp
@@ -1,3 +1,7 @@
+#ifndef NITRO_LOG_MIN_SEVERITY
+#error "NITRO_LOG_MIN_SEVERITY should be set by the build system, but isn't!"
+#endif
+
 #define CATCH_CONFIG_MAIN
 #include <catch.hpp>
 


### PR DESCRIPTION
This includes:

- providing a INTERFACE library
- get my hands off Compiler flags
- Addings a Nitro namespace for CMake
- Sacrificing goats to travis gods, such that they build that shit

This enables other projects to add Nitro just through the use of `add_subdirectory`. This probably won't work anyways 😞