### PR TITLE
Add replace_all and starts_with function

### DIFF
--- a/include/nitro/lang/string.hpp
+++ b/include/nitro/lang/string.hpp
@@ -107,13 +107,14 @@ namespace lang
         return full.find(beginning) == 0;
     }
 
-    inline void replace_all(std::string& str, const std::string& from, const std::string& to)
+    inline void replace_all(std::string& str, const std::string& to_replace,
+                            const std::string& replacement)
     {
         size_t start_pos = 0;
-        while ((start_pos = str.find(from, start_pos)) != std::string::npos)
+        while ((start_pos = str.find(to_replace, start_pos)) != std::string::npos)
         {
-            str.replace(start_pos, from.length(), to);
-            start_pos += to.length();
+            str.replace(start_pos, to_replace.length(), replacement);
+            start_pos += replacement.length();
         }
     }
 } // namespace lang

--- a/include/nitro/lang/string.hpp
+++ b/include/nitro/lang/string.hpp
@@ -102,5 +102,19 @@ namespace lang
         return result;
     }
 
+    inline bool starts_with(const std::string& full, const std::string& beginning)
+    {
+        return full.find(beginning) == 0;
+    }
+
+    inline void replace_all(std::string& str, const std::string& from, const std::string& to)
+    {
+        size_t start_pos = 0;
+        while ((start_pos = str.find(from, start_pos)) != std::string::npos)
+        {
+            str.replace(start_pos, from.length(), to);
+            start_pos += to.length();
+        }
+    }
 } // namespace lang
 } // namespace nitro

--- a/tests/string_test.cpp
+++ b/tests/string_test.cpp
@@ -139,6 +139,19 @@ TEST_CASE("String starts_with works", "[lang]")
     {
         REQUIRE(nitro::lang::starts_with("Egg", "Egg and Spam") == false);
     }
+    SECTION("All strings start with the empty string")
+    {
+        REQUIRE(nitro::lang::starts_with("Egg", "") == true);
+    }
+    SECTION("The empty string starts with the empty string")
+    {
+        REQUIRE(nitro::lang::starts_with("", "") == true);
+    }
+
+    SECTION("the empty string starts with no string")
+    {
+        REQUIRE(nitro::lang::starts_with("", "Egg") == false);
+    }
 }
 
 TEST_CASE("String replace_all works", "[lang]")
@@ -154,5 +167,17 @@ TEST_CASE("String replace_all works", "[lang]")
         std::string str("Egg and Spam");
         nitro::lang::replace_all(str, " and Spam", ", Sausage and Spam");
         REQUIRE(str == "Egg, Sausage and Spam");
+    }
+    SECTION("Replacing with empty string")
+    {
+        std::string str("Egg, Spam, Spam, Spam");
+        nitro::lang::replace_all(str, ", Spam", "");
+        REQUIRE(str == "Egg");
+    }
+    SECTION("Replaces in an empty string")
+    {
+        std::string str("");
+        nitro::lang::replace_all(str, "Egg", "Spam");
+        REQUIRE(str == "");
     }
 }

--- a/tests/string_test.cpp
+++ b/tests/string_test.cpp
@@ -122,3 +122,37 @@ TEST_CASE("String split works", "[lang]")
         REQUIRE(split[0] == "1234##5678##9101112");
     }
 }
+
+TEST_CASE("String starts_with works", "[lang]")
+{
+    SECTION("Egg and Spam starts with Egg")
+    {
+        REQUIRE(nitro::lang::starts_with("Egg and Spam", "Egg") == true);
+    }
+
+    SECTION("Egg and Spam doesn't sart with Spam")
+    {
+        REQUIRE(nitro::lang::starts_with("Egg and Spam", "Spam") == false);
+    }
+
+    SECTION("Egg doesn't start with Egg and Spam")
+    {
+        REQUIRE(nitro::lang::starts_with("Egg", "Egg and Spam") == false);
+    }
+}
+
+TEST_CASE("String replace_all works", "[lang]")
+{
+    SECTION("Egg, Bacon and Bacon becomes Egg, Spam and Spam")
+    {
+        std::string str("Egg, Bacon and Bacon");
+        nitro::lang::replace_all(str, "Bacon", "Spam");
+        REQUIRE(str == "Egg, Spam and Spam");
+    }
+    SECTION("replace_all handles replaces that are longer than the original")
+    {
+        std::string str("Egg and Spam");
+        nitro::lang::replace_all(str, " and Spam", ", Sausage and Spam");
+        REQUIRE(str == "Egg, Sausage and Spam");
+    }
+}


### PR DESCRIPTION
This adds a boost::replace_all and a boost::starts_with replacement to nitro for the lo2s boost removal effort 