### PR TITLE
Added Grouping for Arguments

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+    "files.associations": {
+        "*.ipp": "cpp",
+        "*.tcc": "cpp"
+    }
+}

--- a/include/nitro/broken_options/option/group.hpp
+++ b/include/nitro/broken_options/option/group.hpp
@@ -48,8 +48,8 @@ namespace broken_options
                        std::map<std::string, broken_options::multi_option>& all_multi_options,
                        std::map<std::string, broken_options::toggle>& all_toggles,
                        const std::string& description = std::string(""))
-        : name_(name), description_(description), all_options_(&all_options),
-          all_multi_options_(&all_multi_options), all_toggles_(&all_toggles)
+        : name_(name), description_(description), all_options_(all_options),
+          all_multi_options_(all_multi_options), all_toggles_(all_toggles)
         {
         }
 
@@ -85,69 +85,78 @@ namespace broken_options
         broken_options::option& option(const std::string& name,
                                        const std::string& description = std::string())
         {
-            if (all_multi_options_->count(name) > 0)
+            if (all_multi_options_.count(name) > 0)
             {
                 raise<parser_error>("Trying to redefine multi_option as option. Name: ", name);
             }
 
-            if (all_toggles_->count(name) > 0)
+            if (all_toggles_.count(name) > 0)
             {
-                raise<parser_error>("Trying to redefine toggle as multi_option. Name: ", name);
+                raise<parser_error>("Trying to redefine toggle as option. Name: ", name);
             }
 
-            if (all_options_->count(name) == 0)
+            if (all_options_.count(name) == 0)
             {
                 auto res =
-                    all_options_->emplace(std::piecewise_construct, std::forward_as_tuple(name),
-                                          std::forward_as_tuple(name, description));
+                    all_options_.emplace(std::piecewise_construct, std::forward_as_tuple(name),
+                                         std::forward_as_tuple(name, description));
 
                 add(res.first->second);
             }
-            return all_options_->at(name);
+            else if (options_.find(name) == options_.end())
+            {
+                raise<parser_error>("Trying to redefine option in another group. Name: ", name);
+            }
+            return all_options_.at(name);
         }
 
         broken_options::multi_option& multi_option(const std::string& name,
                                                    const std::string& description = std::string())
         {
-            if (all_options_->count(name) > 0)
+            if (all_options_.count(name) > 0)
             {
                 raise<parser_error>("Trying to redefine option as multi_option. Name: ", name);
             }
 
-            if (all_toggles_->count(name) > 0)
+            if (all_toggles_.count(name) > 0)
             {
                 raise<parser_error>("Trying to redefine toggle as multi_option. Name: ", name);
             }
 
-            if (all_multi_options_->count(name) == 0)
+            if (all_multi_options_.count(name) == 0)
             {
-                auto res = all_multi_options_->emplace(std::piecewise_construct,
-                                                       std::forward_as_tuple(name),
-                                                       std::forward_as_tuple(name, description));
+                auto res = all_multi_options_.emplace(std::piecewise_construct,
+                                                      std::forward_as_tuple(name),
+                                                      std::forward_as_tuple(name, description));
 
                 add(res.first->second);
             }
-            return all_multi_options_->at(name);
+            else if (options_.find(name) == options_.end())
+            {
+                raise<parser_error>("Trying to redefine multi_option in another group. Name: ",
+                                    name);
+            }
+            return all_multi_options_.at(name);
         }
 
         broken_options::toggle& toggle(const std::string& name,
                                        const std::string& description = std::string())
         {
-            if (all_options_->count(name) > 0)
+            if (all_options_.count(name) > 0)
             {
                 raise<parser_error>("Trying to redefine option as multi_option. Name: ", name);
             }
 
-            if (all_multi_options_->count(name) > 0)
+            if (all_multi_options_.count(name) > 0)
             {
                 raise<parser_error>("Trying to redefine multi_option as option. Name: ", name);
             }
 
-            if (all_toggles_->count(name) == 0)
+            if (all_toggles_.count(name) == 0)
             {
                 auto res =
-                    all_toggles_->emplace(std::piecewise_construct, std::forward_as_tuple(name),
-                                          std::forward_as_tuple(name, description));
+                    all_toggles_.emplace(std::piecewise_construct, std::forward_as_tuple(name),
+                                         std::forward_as_tuple(name, description));
 
                 add(res.first->second);
             }
@@ -155,7 +164,7 @@ namespace broken_options
             {
                 raise<parser_error>("Trying to redefine toggle in another group. Name: ", name);
             }
-            return all_toggles_->at(name);
+            return all_toggles_.at(name);
         }
 
     private:
@@ -163,9 +172,9 @@ namespace broken_options
         std::string description_;
         std::map<std::string, std::reference_wrapper<base>> options_;
 
-        std::map<std::string, broken_options::option>* all_options_;
-        std::map<std::string, broken_options::multi_option>* all_multi_options_;
-        std::map<std::string, broken_options::toggle>* all_toggles_;
+        std::map<std::string, broken_options::option>& all_options_;
+        std::map<std::string, broken_options::multi_option>& all_multi_options_;
+        std::map<std::string, broken_options::toggle>& all_toggles_;
     };
 } // namespace broken_options
 } // namespace nitro

--- a/include/nitro/broken_options/option/group.hpp
+++ b/include/nitro/broken_options/option/group.hpp
@@ -176,5 +176,39 @@ namespace broken_options
         std::map<std::string, broken_options::multi_option>& all_multi_options_;
         std::map<std::string, broken_options::toggle>& all_toggles_;
     };
+
+    class proxy_argument_group
+    {
+    private:
+        argument_group& argument_group_;
+
+    public:
+        proxy_argument_group(argument_group& argument_group) : argument_group_(argument_group)
+        {
+        }
+
+        broken_options::option& option(const std::string& name,
+                                       const std::string& description = std::string(""))
+        {
+            return argument_group_.option(name, description);
+        }
+
+        broken_options::multi_option& multi_option(const std::string& name,
+                                                   const std::string& description = std::string(""))
+        {
+            return argument_group_.multi_option(name, description);
+        }
+
+        broken_options::toggle& toggle(const std::string& name,
+                                       const std::string& description = std::string(""))
+        {
+            return argument_group_.toggle(name, description);
+        }
+
+        bool operator==(const proxy_argument_group& rhs) const
+        {
+            return &argument_group_ == &rhs.argument_group_;
+        }
+    };
 } // namespace broken_options
 } // namespace nitro

--- a/include/nitro/broken_options/option/group.hpp
+++ b/include/nitro/broken_options/option/group.hpp
@@ -38,14 +38,14 @@ namespace nitro
 {
 namespace broken_options
 {
-    class option_group
+    class argument_group
     {
     public:
-        option_group(const std::string& name,
-                     std::map<std::string, broken_options::option>& all_options,
-                     std::map<std::string, broken_options::multi_option>& all_multi_options,
-                     std::map<std::string, broken_options::toggle>& all_toggles,
-                     const std::string& description = std::string(""))
+        argument_group(const std::string& name,
+                       std::map<std::string, broken_options::option>& all_options,
+                       std::map<std::string, broken_options::multi_option>& all_multi_options,
+                       std::map<std::string, broken_options::toggle>& all_toggles,
+                       const std::string& description = std::string(""))
         : name_(name), description_(description), all_options_(all_options),
           all_multi_options_(all_multi_options), all_toggles_(all_toggles)
         {
@@ -80,7 +80,8 @@ namespace broken_options
             }
         }
 
-        broken_options::option& option(const std::string& name, const std::string& description)
+        broken_options::option& option(const std::string& name,
+                                       const std::string& description = std::string())
         {
             if (all_multi_options_.count(name) > 0)
             {
@@ -104,7 +105,7 @@ namespace broken_options
         }
 
         broken_options::multi_option& multi_option(const std::string& name,
-                                                   const std::string& description)
+                                                   const std::string& description = std::string())
         {
             if (all_options_.count(name) > 0)
             {
@@ -127,7 +128,8 @@ namespace broken_options
             return all_multi_options_.at(name);
         }
 
-        broken_options::toggle& toggle(const std::string& name, const std::string& description)
+        broken_options::toggle& toggle(const std::string& name,
+                                       const std::string& description = std::string())
         {
             if (all_options_.count(name) > 0)
             {

--- a/include/nitro/broken_options/option/group.hpp
+++ b/include/nitro/broken_options/option/group.hpp
@@ -38,10 +38,10 @@ namespace nitro
 {
 namespace broken_options
 {
-    class group
+    class option_group
     {
     public:
-        group(const std::string& name, const std::string& description = std::string(""))
+        option_group(const std::string& name, const std::string& description = std::string(""))
         : name_(name), description_(description)
         {
         }
@@ -51,7 +51,17 @@ namespace broken_options
             options_.emplace(option.name(), std::ref(option));
         }
 
-        void usage(std::ostream& s)
+        const std::string& name() const
+        {
+            return name_;
+        }
+
+        std::size_t size() const
+        {
+            return options_.size();
+        }
+
+        void usage(std::ostream& s) const
         {
             s << name_ << ":" << std::endl;
             if (description_.size())

--- a/include/nitro/broken_options/option/group.hpp
+++ b/include/nitro/broken_options/option/group.hpp
@@ -63,7 +63,7 @@ namespace broken_options
 
         void usage(std::ostream& s) const
         {
-            s << name_ << ":" << std::endl;
+            s << std::endl << name_ << ":" << std::endl;
             if (description_.size())
             {
                 s << std::endl << description_ << std::endl << std::endl;

--- a/include/nitro/broken_options/option/group.hpp
+++ b/include/nitro/broken_options/option/group.hpp
@@ -28,7 +28,9 @@
 
 #pragma once
 
-#include <nitro/broken_options/option/base.hpp>
+#include <nitro/broken_options/option/multi_option.hpp>
+#include <nitro/broken_options/option/option.hpp>
+#include <nitro/broken_options/option/toggle.hpp>
 
 #include <functional>
 #include <iostream>
@@ -46,8 +48,8 @@ namespace broken_options
                        std::map<std::string, broken_options::multi_option>& all_multi_options,
                        std::map<std::string, broken_options::toggle>& all_toggles,
                        const std::string& description = std::string(""))
-        : name_(name), description_(description), all_options_(all_options),
-          all_multi_options_(all_multi_options), all_toggles_(all_toggles)
+        : name_(name), description_(description), all_options_(&all_options),
+          all_multi_options_(&all_multi_options), all_toggles_(&all_toggles)
         {
         }
 
@@ -83,73 +85,77 @@ namespace broken_options
         broken_options::option& option(const std::string& name,
                                        const std::string& description = std::string())
         {
-            if (all_multi_options_.count(name) > 0)
+            if (all_multi_options_->count(name) > 0)
             {
                 raise<parser_error>("Trying to redefine multi_option as option. Name: ", name);
             }
 
-            if (all_toggles_.count(name) > 0)
+            if (all_toggles_->count(name) > 0)
             {
                 raise<parser_error>("Trying to redefine toggle as multi_option. Name: ", name);
             }
 
-            if (all_options_.count(name) == 0)
+            if (all_options_->count(name) == 0)
             {
                 auto res =
-                    all_options_.emplace(std::piecewise_construct, std::forward_as_tuple(name),
-                                         std::forward_as_tuple(name, description));
+                    all_options_->emplace(std::piecewise_construct, std::forward_as_tuple(name),
+                                          std::forward_as_tuple(name, description));
 
                 add(res.first->second);
             }
-            return all_options_.at(name);
+            return all_options_->at(name);
         }
 
         broken_options::multi_option& multi_option(const std::string& name,
                                                    const std::string& description = std::string())
         {
-            if (all_options_.count(name) > 0)
+            if (all_options_->count(name) > 0)
             {
                 raise<parser_error>("Trying to redefine option as multi_option. Name: ", name);
             }
 
-            if (all_toggles_.count(name) > 0)
+            if (all_toggles_->count(name) > 0)
             {
                 raise<parser_error>("Trying to redefine toggle as multi_option. Name: ", name);
             }
 
-            if (all_multi_options_.count(name) == 0)
+            if (all_multi_options_->count(name) == 0)
             {
-                auto res = all_multi_options_.emplace(std::piecewise_construct,
-                                                      std::forward_as_tuple(name),
-                                                      std::forward_as_tuple(name, description));
+                auto res = all_multi_options_->emplace(std::piecewise_construct,
+                                                       std::forward_as_tuple(name),
+                                                       std::forward_as_tuple(name, description));
 
                 add(res.first->second);
             }
-            return all_multi_options_.at(name);
+            return all_multi_options_->at(name);
         }
 
         broken_options::toggle& toggle(const std::string& name,
                                        const std::string& description = std::string())
         {
-            if (all_options_.count(name) > 0)
+            if (all_options_->count(name) > 0)
             {
                 raise<parser_error>("Trying to redefine option as multi_option. Name: ", name);
             }
 
-            if (all_multi_options_.count(name) > 0)
+            if (all_multi_options_->count(name) > 0)
             {
                 raise<parser_error>("Trying to redefine multi_option as option. Name: ", name);
             }
 
-            if (all_toggles_.count(name) == 0)
+            if (all_toggles_->count(name) == 0)
             {
                 auto res =
-                    all_toggles_.emplace(std::piecewise_construct, std::forward_as_tuple(name),
-                                         std::forward_as_tuple(name, description));
+                    all_toggles_->emplace(std::piecewise_construct, std::forward_as_tuple(name),
+                                          std::forward_as_tuple(name, description));
 
                 add(res.first->second);
             }
-            return all_toggles_.at(name);
+            else if (options_.find(name) == options_.end())
+            {
+                raise<parser_error>("Trying to redefine toggle in another group. Name: ", name);
+            }
+            return all_toggles_->at(name);
         }
 
     private:
@@ -157,9 +163,9 @@ namespace broken_options
         std::string description_;
         std::map<std::string, std::reference_wrapper<base>> options_;
 
-        std::map<std::string, broken_options::option>& all_options_;
-        std::map<std::string, broken_options::multi_option>& all_multi_options_;
-        std::map<std::string, broken_options::toggle>& all_toggles_;
+        std::map<std::string, broken_options::option>* all_options_;
+        std::map<std::string, broken_options::multi_option>* all_multi_options_;
+        std::map<std::string, broken_options::toggle>* all_toggles_;
     };
 } // namespace broken_options
 } // namespace nitro

--- a/include/nitro/broken_options/parser.hpp
+++ b/include/nitro/broken_options/parser.hpp
@@ -41,7 +41,6 @@
 
 #include <iostream>
 #include <map>
-#include <set>
 #include <string>
 #include <vector>
 
@@ -71,8 +70,8 @@ namespace broken_options
         auto toggle(const std::string& name, const std::string& description = std::string(""))
             -> broken_options::toggle&;
 
-        broken_options::option_group& group(const std::string& group_name,
-                                            const std::string& description = std::string(""));
+        broken_options::argument_group& group(const std::string& group_name,
+                                              const std::string& description = std::string(""));
 
         void accept_positionals(std::size_t amount = std::numeric_limits<std::size_t>::max());
         void positional_name(const std::string& name);
@@ -107,7 +106,7 @@ namespace broken_options
         std::map<std::string, broken_options::multi_option> multi_options_;
         std::map<std::string, broken_options::toggle> toggles_;
 
-        std::map<std::string, option_group> groups_;
+        std::map<std::string, argument_group> groups_;
 
         std::size_t allowed_positionals_ = 0;
         std::string positional_name_ = "args";

--- a/include/nitro/broken_options/parser.hpp
+++ b/include/nitro/broken_options/parser.hpp
@@ -43,19 +43,22 @@
 #include <map>
 #include <string>
 #include <vector>
+#include <set>
 
 namespace nitro
 {
 namespace broken_options
 {
+    class group_assigner;
 
     class parser
     {
     public:
         parser(const std::string& app_name = std::string("main"),
                const std::string& about = std::string(""))
-        : app_name_(app_name), about_(about), arguments_("arguments")
+        : app_name_(app_name), about_(about)
         {
+            create_group("arguments");
         }
 
         auto parse(int argc, const char* const argv[]) -> options;
@@ -66,6 +69,15 @@ namespace broken_options
         auto multi_option(const std::string& name, const std::string& description = std::string(""))
             -> broken_options::multi_option&;
         auto toggle(const std::string& name, const std::string& description = std::string(""))
+            -> broken_options::toggle&;
+
+        void create_group(const std::string& group_name, const std::string& description = std::string(""));
+        broken_options::group_assigner group(const std::string& group_name);
+        auto group_option(const std::string& group_name, const std::string& name, const std::string& description = std::string(""))
+            -> broken_options::option&;
+        auto group_multi_option(const std::string& group_name, const std::string& name, const std::string& description = std::string(""))
+            -> broken_options::multi_option&;
+        auto group_toggle(const std::string& group_name, const std::string& name, const std::string& description = std::string(""))
             -> broken_options::toggle&;
 
         void accept_positionals(std::size_t amount = std::numeric_limits<std::size_t>::max());
@@ -100,10 +112,34 @@ namespace broken_options
         std::map<std::string, broken_options::multi_option> multi_options_;
         std::map<std::string, broken_options::toggle> toggles_;
 
-        group arguments_;
+        std::map<std::string,option_group> groups_;
 
         std::size_t allowed_positionals_ = 0;
         std::string positional_name_ = "args";
+    };
+
+    class group_assigner
+    {
+    public:
+        group_assigner(const std::string& group_name, parser& parser)
+        :parser_(parser),group_name_(group_name)
+        {
+        }
+        auto option(const std::string& name, const std::string& description = std::string(""))
+        {
+            return parser_.group_option(group_name_,name,description);
+        }
+        auto multi_option(const std::string& name, const std::string& description = std::string(""))
+        {
+            return parser_.group_multi_option(group_name_,name,description);
+        }
+        auto toggle(const std::string& name, const std::string& description = std::string(""))
+        {
+            return parser_.group_toggle(group_name_,name,description);
+        }
+    private:
+        parser& parser_;
+        std::string group_name_;
     };
 } // namespace broken_options
 } // namespace nitro

--- a/include/nitro/broken_options/parser.hpp
+++ b/include/nitro/broken_options/parser.hpp
@@ -70,8 +70,8 @@ namespace broken_options
         auto toggle(const std::string& name, const std::string& description = std::string(""))
             -> broken_options::toggle&;
 
-        broken_options::argument_group& group(const std::string& group_name,
-                                              const std::string& description = std::string(""));
+        broken_options::proxy_argument_group
+        group(const std::string& group_name, const std::string& description = std::string(""));
 
         void accept_positionals(std::size_t amount = std::numeric_limits<std::size_t>::max());
         void positional_name(const std::string& name);

--- a/include/nitro/broken_options/parser.hpp
+++ b/include/nitro/broken_options/parser.hpp
@@ -49,27 +49,6 @@ namespace nitro
 {
 namespace broken_options
 {
-    class parser;
-
-    class group_assigner
-    {
-    public:
-        group_assigner(const std::string& group_name, parser& parser)
-        : parser_(parser), group_name_(group_name)
-        {
-        }
-        broken_options::option& option(const std::string& name,
-                                       const std::string& description = std::string(""));
-        broken_options::multi_option&
-        multi_option(const std::string& name, const std::string& description = std::string(""));
-        broken_options::toggle& toggle(const std::string& name,
-                                       const std::string& description = std::string(""));
-
-    private:
-        parser& parser_;
-        std::string group_name_;
-    };
-
     class parser
     {
     public:
@@ -77,10 +56,12 @@ namespace broken_options
                const std::string& about = std::string(""))
         : app_name_(app_name), about_(about)
         {
-            auto _ = group("arguments");
+            group("arguments");
         }
 
         auto parse(int argc, const char* const argv[]) -> options;
+        void default_group(const std::string& group_name,
+                           const std::string& description = std::string(""));
 
     public:
         auto option(const std::string& name, const std::string& description = std::string(""))
@@ -90,17 +71,8 @@ namespace broken_options
         auto toggle(const std::string& name, const std::string& description = std::string(""))
             -> broken_options::toggle&;
 
-        broken_options::group_assigner group(const std::string& group_name,
-                                             const std::string& description = std::string(""));
-        auto group_option(const std::string& group_name, const std::string& name,
-                          const std::string& description = std::string(""))
-            -> broken_options::option&;
-        auto group_multi_option(const std::string& group_name, const std::string& name,
-                                const std::string& description = std::string(""))
-            -> broken_options::multi_option&;
-        auto group_toggle(const std::string& group_name, const std::string& name,
-                          const std::string& description = std::string(""))
-            -> broken_options::toggle&;
+        broken_options::option_group& group(const std::string& group_name,
+                                            const std::string& description = std::string(""));
 
         void accept_positionals(std::size_t amount = std::numeric_limits<std::size_t>::max());
         void positional_name(const std::string& name);
@@ -129,6 +101,7 @@ namespace broken_options
     private:
         std::string app_name_;
         std::string about_;
+        std::string default_group_name_ = "arguments";
 
         std::map<std::string, broken_options::option> options_;
         std::map<std::string, broken_options::multi_option> multi_options_;

--- a/include/nitro/broken_options/parser.hpp
+++ b/include/nitro/broken_options/parser.hpp
@@ -41,9 +41,9 @@
 
 #include <iostream>
 #include <map>
+#include <set>
 #include <string>
 #include <vector>
-#include <set>
 
 namespace nitro
 {
@@ -71,13 +71,16 @@ namespace broken_options
         auto toggle(const std::string& name, const std::string& description = std::string(""))
             -> broken_options::toggle&;
 
-        void create_group(const std::string& group_name, const std::string& description = std::string(""));
-        broken_options::group_assigner group(const std::string& group_name);
-        auto group_option(const std::string& group_name, const std::string& name, const std::string& description = std::string(""))
+        broken_options::group_assigner group(const std::string& group_name,
+                                             const std::string& description = std::string(""));
+        auto group_option(const std::string& group_name, const std::string& name,
+                          const std::string& description = std::string(""))
             -> broken_options::option&;
-        auto group_multi_option(const std::string& group_name, const std::string& name, const std::string& description = std::string(""))
+        auto group_multi_option(const std::string& group_name, const std::string& name,
+                                const std::string& description = std::string(""))
             -> broken_options::multi_option&;
-        auto group_toggle(const std::string& group_name, const std::string& name, const std::string& description = std::string(""))
+        auto group_toggle(const std::string& group_name, const std::string& name,
+                          const std::string& description = std::string(""))
             -> broken_options::toggle&;
 
         void accept_positionals(std::size_t amount = std::numeric_limits<std::size_t>::max());
@@ -112,7 +115,7 @@ namespace broken_options
         std::map<std::string, broken_options::multi_option> multi_options_;
         std::map<std::string, broken_options::toggle> toggles_;
 
-        std::map<std::string,option_group> groups_;
+        std::map<std::string, option_group> groups_;
 
         std::size_t allowed_positionals_ = 0;
         std::string positional_name_ = "args";
@@ -122,21 +125,22 @@ namespace broken_options
     {
     public:
         group_assigner(const std::string& group_name, parser& parser)
-        :parser_(parser),group_name_(group_name)
+        : parser_(parser), group_name_(group_name)
         {
         }
         auto option(const std::string& name, const std::string& description = std::string(""))
         {
-            return parser_.group_option(group_name_,name,description);
+            return parser_.group_option(group_name_, name, description);
         }
         auto multi_option(const std::string& name, const std::string& description = std::string(""))
         {
-            return parser_.group_multi_option(group_name_,name,description);
+            return parser_.group_multi_option(group_name_, name, description);
         }
         auto toggle(const std::string& name, const std::string& description = std::string(""))
         {
-            return parser_.group_toggle(group_name_,name,description);
+            return parser_.group_toggle(group_name_, name, description);
         }
+
     private:
         parser& parser_;
         std::string group_name_;

--- a/include/nitro/broken_options/parser.hpp
+++ b/include/nitro/broken_options/parser.hpp
@@ -49,7 +49,26 @@ namespace nitro
 {
 namespace broken_options
 {
-    class group_assigner;
+    class parser;
+
+    class group_assigner
+    {
+    public:
+        group_assigner(const std::string& group_name, parser& parser)
+        : parser_(parser), group_name_(group_name)
+        {
+        }
+        broken_options::option& option(const std::string& name,
+                                       const std::string& description = std::string(""));
+        broken_options::multi_option& multi_option(const std::string& name,
+                                             const std::string& description = std::string(""));
+        broken_options::toggle& toggle(const std::string& name,
+                                       const std::string& description = std::string(""));
+
+    private:
+        parser& parser_;
+        std::string group_name_;
+    };
 
     class parser
     {
@@ -58,7 +77,7 @@ namespace broken_options
                const std::string& about = std::string(""))
         : app_name_(app_name), about_(about)
         {
-            create_group("arguments");
+            auto _ = group("arguments");
         }
 
         auto parse(int argc, const char* const argv[]) -> options;
@@ -119,31 +138,6 @@ namespace broken_options
 
         std::size_t allowed_positionals_ = 0;
         std::string positional_name_ = "args";
-    };
-
-    class group_assigner
-    {
-    public:
-        group_assigner(const std::string& group_name, parser& parser)
-        : parser_(parser), group_name_(group_name)
-        {
-        }
-        auto option(const std::string& name, const std::string& description = std::string(""))
-        {
-            return parser_.group_option(group_name_, name, description);
-        }
-        auto multi_option(const std::string& name, const std::string& description = std::string(""))
-        {
-            return parser_.group_multi_option(group_name_, name, description);
-        }
-        auto toggle(const std::string& name, const std::string& description = std::string(""))
-        {
-            return parser_.group_toggle(group_name_, name, description);
-        }
-
-    private:
-        parser& parser_;
-        std::string group_name_;
     };
 } // namespace broken_options
 } // namespace nitro

--- a/include/nitro/broken_options/parser.hpp
+++ b/include/nitro/broken_options/parser.hpp
@@ -60,8 +60,8 @@ namespace broken_options
         }
         broken_options::option& option(const std::string& name,
                                        const std::string& description = std::string(""));
-        broken_options::multi_option& multi_option(const std::string& name,
-                                             const std::string& description = std::string(""));
+        broken_options::multi_option&
+        multi_option(const std::string& name, const std::string& description = std::string(""));
         broken_options::toggle& toggle(const std::string& name,
                                        const std::string& description = std::string(""));
 

--- a/include/nitro/broken_options/parser.ipp
+++ b/include/nitro/broken_options/parser.ipp
@@ -68,8 +68,8 @@ namespace broken_options
         }
     }
 
-    broken_options::argument_group& parser::group(const std::string& group_name,
-                                                  const std::string& description)
+    broken_options::proxy_argument_group parser::group(const std::string& group_name,
+                                                       const std::string& description)
     {
         if (groups_.find(group_name) == groups_.end())
         {
@@ -81,7 +81,7 @@ namespace broken_options
             raise<parser_error>("Trying to redefine group. Name: ", group_name);
         }
 
-        return groups_.find(group_name)->second;
+        return proxy_argument_group(groups_.at(group_name));
     }
 
     broken_options::option& parser::option(const std::string& name, const std::string& description)

--- a/include/nitro/broken_options/parser.ipp
+++ b/include/nitro/broken_options/parser.ipp
@@ -59,8 +59,8 @@ namespace broken_options
         default_group_name_ = group_name;
         if (groups_.find(group_name) == groups_.end())
         {
-            groups_.emplace(group_name, option_group(group_name, options_, multi_options_, toggles_,
-                                                     description));
+            groups_.emplace(group_name, argument_group(group_name, options_, multi_options_,
+                                                       toggles_, description));
         }
         else if (description.size())
         {
@@ -68,13 +68,13 @@ namespace broken_options
         }
     }
 
-    broken_options::option_group& parser::group(const std::string& group_name,
-                                                const std::string& description)
+    broken_options::argument_group& parser::group(const std::string& group_name,
+                                                  const std::string& description)
     {
         if (groups_.find(group_name) == groups_.end())
         {
-            groups_.emplace(group_name, option_group(group_name, options_, multi_options_, toggles_,
-                                                     description));
+            groups_.emplace(group_name, argument_group(group_name, options_, multi_options_,
+                                                       toggles_, description));
         }
         else if (description.size())
         {
@@ -104,8 +104,8 @@ namespace broken_options
             auto group_loc = groups_.find(default_group_name_);
             if (group_loc == groups_.end())
             {
-                groups_.emplace(default_group_name_, option_group(default_group_name_, options_,
-                                                                  multi_options_, toggles_));
+                groups_.emplace(default_group_name_, argument_group(default_group_name_, options_,
+                                                                    multi_options_, toggles_));
                 group_loc = groups_.find(default_group_name_);
             }
             group_loc->second.add(res.first->second);
@@ -134,8 +134,8 @@ namespace broken_options
             auto group_loc = groups_.find(default_group_name_);
             if (group_loc == groups_.end())
             {
-                groups_.emplace(default_group_name_, option_group(default_group_name_, options_,
-                                                                  multi_options_, toggles_));
+                groups_.emplace(default_group_name_, argument_group(default_group_name_, options_,
+                                                                    multi_options_, toggles_));
                 group_loc = groups_.find(default_group_name_);
             }
             group_loc->second.add(res.first->second);
@@ -163,8 +163,8 @@ namespace broken_options
             auto group_loc = groups_.find(default_group_name_);
             if (group_loc == groups_.end())
             {
-                groups_.emplace(default_group_name_, option_group(default_group_name_, options_,
-                                                                  multi_options_, toggles_));
+                groups_.emplace(default_group_name_, argument_group(default_group_name_, options_,
+                                                                    multi_options_, toggles_));
                 group_loc = groups_.find(default_group_name_);
             }
             group_loc->second.add(res.first->second);
@@ -450,22 +450,6 @@ namespace broken_options
         {
             f(option.second);
         }
-    }
-
-    broken_options::option& group_assigner::option(const std::string& name,
-                                                   const std::string& description)
-    {
-        return parser_.group_option(group_name_, name, description);
-    }
-    broken_options::multi_option& group_assigner::multi_option(const std::string& name,
-                                                               const std::string& description)
-    {
-        return parser_.group_multi_option(group_name_, name, description);
-    }
-    broken_options::toggle& group_assigner::toggle(const std::string& name,
-                                                   const std::string& description)
-    {
-        return parser_.group_toggle(group_name_, name, description);
     }
 
 } // namespace broken_options

--- a/include/nitro/broken_options/parser.ipp
+++ b/include/nitro/broken_options/parser.ipp
@@ -46,7 +46,7 @@ namespace broken_options
         {
             groups_.emplace(group_name, option_group(group_name, description));
         }
-        else if (description)
+        else if (description.size())
         {
             raise<parser_error>("Trying to redefine group. Name: ", group_name);
         }
@@ -285,7 +285,7 @@ namespace broken_options
 
         for (const auto& group_pair : groups_)
         {
-            if (group.first == "arguments" && !print_default_group)
+            if (group_pair.first == "arguments" && !print_default_group)
             {
                 continue;
             }
@@ -438,6 +438,22 @@ namespace broken_options
         {
             f(option.second);
         }
+    }
+
+    broken_options::option& group_assigner::option(const std::string& name,
+                                                   const std::string& description)
+    {
+        return parser_.group_option(group_name_, name, description);
+    }
+    broken_options::multi_option& group_assigner::multi_option(const std::string& name,
+                                                               const std::string& description)
+    {
+        return parser_.group_multi_option(group_name_, name, description);
+    }
+    broken_options::toggle& group_assigner::toggle(const std::string& name,
+                                                   const std::string& description)
+    {
+        return parser_.group_toggle(group_name_, name, description);
     }
 
 } // namespace broken_options

--- a/include/nitro/broken_options/parser.ipp
+++ b/include/nitro/broken_options/parser.ipp
@@ -39,28 +39,28 @@ namespace nitro
 {
 namespace broken_options
 {
-    void parser::create_group(const std::string& group_name, const std::string& description)
+    broken_options::group_assigner parser::group(const std::string& group_name,
+                                                 const std::string& description)
     {
-        if ( groups_.find(group_name) != groups_.end() )
+        if (groups_.find(group_name) == groups_.end())
         {
-            raise<parser_error>("Trying to redefine group. Group name: ", group_name);
+            groups_.emplace(group_name, option_group(group_name, description));
+        }
+        else if (description)
+        {
+            raise<parser_error>("Trying to redefine group. Name: ", group_name);
         }
 
-        groups_.emplace(group_name,option_group(group_name,description));
-    }
-
-    broken_options::group_assigner parser::group(const std::string& group_name)
-    {
-        return group_assigner(group_name,*this);
+        return group_assigner(group_name, *this);
     }
 
     broken_options::option& parser::option(const std::string& name, const std::string& description)
     {
-        return group_option("arguments",name,description);
+        return group_option("arguments", name, description);
     }
 
-    broken_options::option& parser::group_option(const std::string& group_name, 
-                                                 const std::string& name, 
+    broken_options::option& parser::group_option(const std::string& group_name,
+                                                 const std::string& name,
                                                  const std::string& description)
     {
         if (multi_options_.count(name) > 0)
@@ -79,9 +79,9 @@ namespace broken_options
                                         std::forward_as_tuple(name, description));
 
             auto group_loc = groups_.find(group_name);
-            if ( group_loc == groups_.end() )
+            if (group_loc == groups_.end())
             {
-                groups_.emplace(group_name,option_group(group_name));
+                groups_.emplace(group_name, option_group(group_name));
                 group_loc = groups_.find(group_name);
             }
             group_loc->second.add(res.first->second);
@@ -92,7 +92,7 @@ namespace broken_options
     broken_options::multi_option& parser::multi_option(const std::string& name,
                                                        const std::string& description)
     {
-        return group_multi_option("arguments",name,description);
+        return group_multi_option("arguments", name, description);
     }
 
     broken_options::multi_option& parser::group_multi_option(const std::string& group_name,
@@ -115,9 +115,9 @@ namespace broken_options
                                               std::forward_as_tuple(name, description));
 
             auto group_loc = groups_.find(group_name);
-            if ( group_loc == groups_.end() )
+            if (group_loc == groups_.end())
             {
-                groups_.emplace(group_name,option_group(group_name));
+                groups_.emplace(group_name, option_group(group_name));
                 group_loc = groups_.find(group_name);
             }
             group_loc->second.add(res.first->second);
@@ -127,11 +127,11 @@ namespace broken_options
 
     broken_options::toggle& parser::toggle(const std::string& name, const std::string& description)
     {
-        return group_toggle("arguments",name,description);
+        return group_toggle("arguments", name, description);
     }
 
-    broken_options::toggle& parser::group_toggle(const std::string& group_name, 
-                                                 const std::string& name, 
+    broken_options::toggle& parser::group_toggle(const std::string& group_name,
+                                                 const std::string& name,
                                                  const std::string& description)
     {
         if (options_.count(name) > 0)
@@ -150,9 +150,9 @@ namespace broken_options
                                         std::forward_as_tuple(name, description));
 
             auto group_loc = groups_.find(group_name);
-            if ( group_loc == groups_.end() )
+            if (group_loc == groups_.end())
             {
-                groups_.emplace(group_name,option_group(group_name));
+                groups_.emplace(group_name, option_group(group_name));
                 group_loc = groups_.find(group_name);
             }
             group_loc->second.add(res.first->second);

--- a/tests/broken_options_test.cpp
+++ b/tests/broken_options_test.cpp
@@ -202,8 +202,8 @@ group2:
         parser.accept_positionals(3);
         parser.positional_name("command line");
 
-        auto grp1 = parser.group("group1", "some text");
-        auto grp2 = parser.group("group2");
+        auto& grp1 = parser.group("group1", "some text");
+        auto& grp2 = parser.group("group2");
 
         grp1.toggle("tog", "some toggle").short_name("t");
         grp1.toggle("togg", "some other toggle").short_name("u");
@@ -244,8 +244,8 @@ about
 
 group1:
 
-  some text
-  
+some text
+
   -o [ --opt ] arg                        some opt
   --opt_long arg                          an option with an very very very very
                                           very very very very very very very
@@ -278,11 +278,15 @@ group2:
 
         CHECK(actual.size() == expected.size());
 
+        std::size_t tmp = 0;
         for (unsigned long i = 0; i < actual.size(); ++i)
         {
             if (actual[i] != expected[i])
             {
                 std::cout << i << " " << actual[i] << " " << expected[i] << std::endl;
+                ++tmp;
+                if (tmp > 100)
+                    break;
             }
         }
 
@@ -368,14 +372,14 @@ test arguments:
 )EXPECTED");
     }
 
-    SECTION("Groups work 2")
+    SECTION("Multiple groups with same name should be one group")
     {
         nitro::broken_options::parser parser("app_name", "about");
 
         std::stringstream s;
 
-        auto grp1 = parser.group("group1");
-        auto grp2 = parser.group("group2");
+        auto& grp1 = parser.group("group1");
+        auto& grp2 = parser.group("group2");
 
         grp1.toggle("tog", "should work");
         REQUIRE_THROWS_AS(grp2.toggle("tog", "should fail"), nitro::broken_options::parser_error);

--- a/tests/broken_options_test.cpp
+++ b/tests/broken_options_test.cpp
@@ -182,7 +182,7 @@ group2:
 
         CHECK(actual.size() == expected.size());
 
-        for(unsigned long i=0; i<actual.size(); ++i)
+        for (unsigned long i = 0; i < actual.size(); ++i)
         {
             if (actual[i] != expected[i])
             {

--- a/tests/broken_options_test.cpp
+++ b/tests/broken_options_test.cpp
@@ -143,6 +143,7 @@ TEST_CASE("Groups work")
 
 about
 
+
 group1:
   -o [ --opt ] arg                        some opt
   --opt_long arg                          an option with an very very very very

--- a/tests/broken_options_test.cpp
+++ b/tests/broken_options_test.cpp
@@ -202,8 +202,8 @@ group2:
         parser.accept_positionals(3);
         parser.positional_name("command line");
 
-        auto& grp1 = parser.group("group1", "some text");
-        auto& grp2 = parser.group("group2");
+        auto grp1 = parser.group("group1", "some text");
+        auto grp2 = parser.group("group2");
 
         grp1.toggle("tog", "some toggle").short_name("t");
         grp1.toggle("togg", "some other toggle").short_name("u");
@@ -378,8 +378,8 @@ test arguments:
 
         std::stringstream s;
 
-        auto& grp1 = parser.group("group1");
-        auto& grp2 = parser.group("group2");
+        auto grp1 = parser.group("group1");
+        auto grp2 = parser.group("group2");
 
         grp1.toggle("tog", "should work");
         REQUIRE_THROWS_AS(grp2.toggle("tog", "should fail"), nitro::broken_options::parser_error);
@@ -391,8 +391,8 @@ test arguments:
 
         std::stringstream s;
 
-        auto grp1 = &parser.group("group1");
-        auto grp2 = &parser.group("group1");
+        auto grp1 = parser.group("group1");
+        auto grp2 = parser.group("group1");
 
         REQUIRE(grp1 == grp2);
     }

--- a/tests/broken_options_test.cpp
+++ b/tests/broken_options_test.cpp
@@ -202,7 +202,7 @@ group2:
         parser.accept_positionals(3);
         parser.positional_name("command line");
 
-        auto grp1 = parser.group("group1");
+        auto grp1 = parser.group("group1", "some text");
         auto grp2 = parser.group("group2");
 
         grp1.toggle("tog", "some toggle").short_name("t");
@@ -243,6 +243,9 @@ about
 
 
 group1:
+
+  some text
+  
   -o [ --opt ] arg                        some opt
   --opt_long arg                          an option with an very very very very
                                           very very very very very very very
@@ -363,6 +366,31 @@ test arguments:
   -t [ --tog ]                            some toggle
   -u [ --togg ]                           some other toggle
 )EXPECTED");
+    }
+
+    SECTION("Groups work 2")
+    {
+        nitro::broken_options::parser parser("app_name", "about");
+
+        std::stringstream s;
+
+        auto grp1 = parser.group("group1");
+        auto grp2 = parser.group("group2");
+
+        grp1.toggle("tog", "should work");
+        REQUIRE_THROWS_AS(grp2.toggle("tog", "should fail"), nitro::broken_options::parser_error);
+    }
+
+    SECTION("Groups work 2")
+    {
+        nitro::broken_options::parser parser("app_name", "about");
+
+        std::stringstream s;
+
+        auto grp1 = &parser.group("group1");
+        auto grp2 = &parser.group("group1");
+
+        REQUIRE(grp1 == grp2);
     }
 }
 

--- a/tests/broken_options_test.cpp
+++ b/tests/broken_options_test.cpp
@@ -63,6 +63,7 @@ TEST_CASE("Usage descriptions work")
 
 about
 
+
 arguments:
   --env-opt arg                           This is an option to set cool stuff.
                                           Can be set using the environment
@@ -109,18 +110,20 @@ TEST_CASE("Groups work")
         parser.group("group1").toggle("togg", "some other toggle").short_name("u");
 
         parser.group("group1").option("opt", "some opt").short_name("o");
-        parser.group("group1").option("opt_with_d", "some opt with a default")
+        parser.group("group1")
+            .option("opt_with_d", "some opt with a default")
             .short_name("d")
             .default_value("default value");
 
-        parser.group("group1").option("opt_nos", "some opt without a short, but a default")
+        parser.group("group1")
+            .option("opt_nos", "some opt without a short, but a default")
             .default_value("default value");
         parser.group("group1").option("opt_nosd", "some opt without short and default");
 
-        parser.group("group1").option("opt_long",
-                      "an option with an very very very very very very very very very "
-                      "very very very very very very very very very very very very very "
-                      "very very very very very very very very long description");
+        parser.group("group1").option(
+            "opt_long", "an option with an very very very very very very very very very "
+                        "very very very very very very very very very very very very very "
+                        "very very very very very very very very long description");
 
         parser.group("group2")
             .option("some_long_named_option",
@@ -132,13 +135,15 @@ TEST_CASE("Groups work")
 
         parser.group("group2").multi_option("mopt", "some multi opt").short_name("m");
 
-        parser.group("group2").option("env-opt", "This is an option to set cool stuff.").env("ENV_OPT");
+        parser.group("group2")
+            .option("env-opt", "This is an option to set cool stuff.")
+            .env("ENV_OPT");
         parser.group("group2").option("env-opt-2").env("ENV_OPT2");
 
         parser.usage(s);
 
-        REQUIRE(
-            s.str() ==
+        auto actual = s.str();
+        std::string expected =
             R"EXPECTED(usage: app_name [-tu] --env-opt --env-opt-2 --opt --opt_long [--opt_nos] --opt_nosd [--opt_with_d] [--some_long_named_option] --mopt [command line ...]
 
 about
@@ -160,6 +165,12 @@ group1:
   -u [ --togg ]                           some other toggle
 
 group2:
+  --env-opt arg                           This is an option to set cool stuff.
+                                          Can be set using the environment
+                                          variable 'ENV_OPT'.
+  --env-opt-2 arg                         Can be set using the environment
+                                          variable 'ENV_OPT2'.
+  -m [ --mopt ] arg                       some multi opt
   -x [ --some_long_named_option ] [=some very long default parameter for this fucking thing]
                                           an option with an very very very very
                                           very very very very very very very
@@ -167,13 +178,19 @@ group2:
                                           very very very very very very very
                                           very very very very very long
                                           description
-  --env-opt arg                           This is an option to set cool stuff.
-                                          Can be set using the environment
-                                          variable 'ENV_OPT'.
-  --env-opt-2 arg                         Can be set using the environment
-                                          variable 'ENV_OPT2'.
-  -m [ --mopt ] arg                       some multi opt
-)EXPECTED");
+)EXPECTED";
+
+        CHECK(actual.size() == expected.size());
+
+        for(unsigned long i=0; i<actual.size(); ++i)
+        {
+            if (actual[i] != expected[i])
+            {
+                std::cout << i << " " << actual[i] << " " << expected[i] << std::endl;
+            }
+        }
+
+        REQUIRE(actual == expected);
     }
 }
 

--- a/tests/broken_options_test.cpp
+++ b/tests/broken_options_test.cpp
@@ -192,6 +192,178 @@ group2:
 
         REQUIRE(actual == expected);
     }
+
+    SECTION("Groups work 2")
+    {
+        nitro::broken_options::parser parser("app_name", "about");
+
+        std::stringstream s;
+
+        parser.accept_positionals(3);
+        parser.positional_name("command line");
+
+        auto grp1 = parser.group("group1");
+        auto grp2 = parser.group("group2");
+
+        grp1.toggle("tog", "some toggle").short_name("t");
+        grp1.toggle("togg", "some other toggle").short_name("u");
+
+        grp1.option("opt", "some opt").short_name("o");
+        grp1.option("opt_with_d", "some opt with a default")
+            .short_name("d")
+            .default_value("default value");
+
+        grp1.option("opt_nos", "some opt without a short, but a default")
+            .default_value("default value");
+        grp1.option("opt_nosd", "some opt without short and default");
+
+        grp1.option("opt_long", "an option with an very very very very very very very very very "
+                                "very very very very very very very very very very very very very "
+                                "very very very very very very very very long description");
+
+        grp2.option("some_long_named_option",
+                    "an option with an very very very very very very very very very "
+                    "very very very very very very very very very very very very very "
+                    "very very very very very very very very long description")
+            .short_name("x")
+            .default_value("some very long default parameter for this fucking thing");
+
+        grp2.multi_option("mopt", "some multi opt").short_name("m");
+
+        grp2.option("env-opt", "This is an option to set cool stuff.").env("ENV_OPT");
+        grp2.option("env-opt-2").env("ENV_OPT2");
+
+        parser.usage(s);
+
+        auto actual = s.str();
+        std::string expected =
+            R"EXPECTED(usage: app_name [-tu] --env-opt --env-opt-2 --opt --opt_long [--opt_nos] --opt_nosd [--opt_with_d] [--some_long_named_option] --mopt [command line ...]
+
+about
+
+
+group1:
+  -o [ --opt ] arg                        some opt
+  --opt_long arg                          an option with an very very very very
+                                          very very very very very very very
+                                          very very very very very very very
+                                          very very very very very very very
+                                          very very very very very long
+                                          description
+  --opt_nos [=default value]              some opt without a short, but a
+                                          default
+  --opt_nosd arg                          some opt without short and default
+  -d [ --opt_with_d ] [=default value]    some opt with a default
+  -t [ --tog ]                            some toggle
+  -u [ --togg ]                           some other toggle
+
+group2:
+  --env-opt arg                           This is an option to set cool stuff.
+                                          Can be set using the environment
+                                          variable 'ENV_OPT'.
+  --env-opt-2 arg                         Can be set using the environment
+                                          variable 'ENV_OPT2'.
+  -m [ --mopt ] arg                       some multi opt
+  -x [ --some_long_named_option ] [=some very long default parameter for this fucking thing]
+                                          an option with an very very very very
+                                          very very very very very very very
+                                          very very very very very very very
+                                          very very very very very very very
+                                          very very very very very long
+                                          description
+)EXPECTED";
+
+        CHECK(actual.size() == expected.size());
+
+        for (unsigned long i = 0; i < actual.size(); ++i)
+        {
+            if (actual[i] != expected[i])
+            {
+                std::cout << i << " " << actual[i] << " " << expected[i] << std::endl;
+            }
+        }
+
+        REQUIRE(actual == expected);
+    }
+
+    SECTION("Change Default Group")
+    {
+        nitro::broken_options::parser parser("app_name", "about");
+
+        std::stringstream s;
+
+        parser.default_group("test arguments");
+        parser.accept_positionals(3);
+        parser.positional_name("command line");
+
+        parser.toggle("tog", "some toggle").short_name("t");
+        parser.toggle("togg", "some other toggle").short_name("u");
+
+        parser.option("opt", "some opt").short_name("o");
+        parser.option("opt_with_d", "some opt with a default")
+            .short_name("d")
+            .default_value("default value");
+
+        parser.option("opt_nos", "some opt without a short, but a default")
+            .default_value("default value");
+        parser.option("opt_nosd", "some opt without short and default");
+
+        parser.option("opt_long",
+                      "an option with an very very very very very very very very very "
+                      "very very very very very very very very very very very very very "
+                      "very very very very very very very very long description");
+
+        parser
+            .option("some_long_named_option",
+                    "an option with an very very very very very very very very very "
+                    "very very very very very very very very very very very very very "
+                    "very very very very very very very very long description")
+            .short_name("x")
+            .default_value("some very long default parameter for this fucking thing");
+
+        parser.multi_option("mopt", "some multi opt").short_name("m");
+
+        parser.option("env-opt", "This is an option to set cool stuff.").env("ENV_OPT");
+        parser.option("env-opt-2").env("ENV_OPT2");
+
+        parser.usage(s);
+
+        REQUIRE(
+            s.str() ==
+            R"EXPECTED(usage: app_name [-tu] --env-opt --env-opt-2 --opt --opt_long [--opt_nos] --opt_nosd [--opt_with_d] [--some_long_named_option] --mopt [command line ...]
+
+about
+
+
+test arguments:
+  --env-opt arg                           This is an option to set cool stuff.
+                                          Can be set using the environment
+                                          variable 'ENV_OPT'.
+  --env-opt-2 arg                         Can be set using the environment
+                                          variable 'ENV_OPT2'.
+  -m [ --mopt ] arg                       some multi opt
+  -o [ --opt ] arg                        some opt
+  --opt_long arg                          an option with an very very very very
+                                          very very very very very very very
+                                          very very very very very very very
+                                          very very very very very very very
+                                          very very very very very long
+                                          description
+  --opt_nos [=default value]              some opt without a short, but a
+                                          default
+  --opt_nosd arg                          some opt without short and default
+  -d [ --opt_with_d ] [=default value]    some opt with a default
+  -x [ --some_long_named_option ] [=some very long default parameter for this fucking thing]
+                                          an option with an very very very very
+                                          very very very very very very very
+                                          very very very very very very very
+                                          very very very very very very very
+                                          very very very very very long
+                                          description
+  -t [ --tog ]                            some toggle
+  -u [ --togg ]                           some other toggle
+)EXPECTED");
+    }
 }
 
 TEST_CASE("Check if short option names are unique")

--- a/tests/broken_options_test.cpp
+++ b/tests/broken_options_test.cpp
@@ -94,6 +94,88 @@ arguments:
     }
 }
 
+TEST_CASE("Groups work")
+{
+    SECTION("Groups work")
+    {
+        nitro::broken_options::parser parser("app_name", "about");
+
+        std::stringstream s;
+
+        parser.accept_positionals(3);
+        parser.positional_name("command line");
+
+        parser.group("group1").toggle("tog", "some toggle").short_name("t");
+        parser.group("group1").toggle("togg", "some other toggle").short_name("u");
+
+        parser.group("group1").option("opt", "some opt").short_name("o");
+        parser.group("group1").option("opt_with_d", "some opt with a default")
+            .short_name("d")
+            .default_value("default value");
+
+        parser.group("group1").option("opt_nos", "some opt without a short, but a default")
+            .default_value("default value");
+        parser.group("group1").option("opt_nosd", "some opt without short and default");
+
+        parser.group("group1").option("opt_long",
+                      "an option with an very very very very very very very very very "
+                      "very very very very very very very very very very very very very "
+                      "very very very very very very very very long description");
+
+        parser.group("group2")
+            .option("some_long_named_option",
+                    "an option with an very very very very very very very very very "
+                    "very very very very very very very very very very very very very "
+                    "very very very very very very very very long description")
+            .short_name("x")
+            .default_value("some very long default parameter for this fucking thing");
+
+        parser.group("group2").multi_option("mopt", "some multi opt").short_name("m");
+
+        parser.group("group2").option("env-opt", "This is an option to set cool stuff.").env("ENV_OPT");
+        parser.group("group2").option("env-opt-2").env("ENV_OPT2");
+
+        parser.usage(s);
+
+        REQUIRE(
+            s.str() ==
+            R"EXPECTED(usage: app_name [-tu] --env-opt --env-opt-2 --opt --opt_long [--opt_nos] --opt_nosd [--opt_with_d] [--some_long_named_option] --mopt [command line ...]
+
+about
+
+group1:
+  -o [ --opt ] arg                        some opt
+  --opt_long arg                          an option with an very very very very
+                                          very very very very very very very
+                                          very very very very very very very
+                                          very very very very very very very
+                                          very very very very very long
+                                          description
+  --opt_nos [=default value]              some opt without a short, but a
+                                          default
+  --opt_nosd arg                          some opt without short and default
+  -d [ --opt_with_d ] [=default value]    some opt with a default
+  -t [ --tog ]                            some toggle
+  -u [ --togg ]                           some other toggle
+
+group2:
+  -x [ --some_long_named_option ] [=some very long default parameter for this fucking thing]
+                                          an option with an very very very very
+                                          very very very very very very very
+                                          very very very very very very very
+                                          very very very very very very very
+                                          very very very very very long
+                                          description
+  --env-opt arg                           This is an option to set cool stuff.
+                                          Can be set using the environment
+                                          variable 'ENV_OPT'.
+  --env-opt-2 arg                         Can be set using the environment
+                                          variable 'ENV_OPT2'.
+  -m [ --mopt ] arg                       some multi opt
+)EXPECTED");
+    }
+}
+
 TEST_CASE("Check if short option names are unique")
 {
     nitro::broken_options::parser parser;


### PR DESCRIPTION
Arguments can be grouped. Groups have a Header and optional a description. Every argument is in the default Group "arguments", if no other group is assigned.

Fixes Issue #22 

Example:

```
nitro::broken_options::parser parser("app_name", "about");

parser.group("group1").option("opt", "some opt").short_name("o");
parser.group("group2").toggle("tog", "some toggle").short_name("t");
parser.group("group2").toggle("togg", "some other toggle").short_name("u");
```


Output:

```
usage: app_name --opt

about


group1:
  -o [ --opt ] arg                        some opt

group2:
  -t [ --tog ]                            some toggle
  -u [ --togg ]                           some other toggle
```
