### PR TITLE
Grouping Version 2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@
 
 build
 .clang_complete
+.vscode

--- a/include/nitro/broken_options/option/base.hpp
+++ b/include/nitro/broken_options/option/base.hpp
@@ -79,9 +79,11 @@ namespace broken_options
 
         virtual void format_value(std::ostream& s) const = 0;
 
-        std::ostream& format(std::ostream& s) const
+        std::ostream& format(std::ostream& s, int left_padding = 2) const
         {
-            s << "  " << std::left << std::setw(38);
+            for (int i = 0; i < left_padding; ++i)
+                s << " ";
+            s << std::left << std::setw(38);
 
             std::stringstream str;
 
@@ -148,7 +150,7 @@ namespace broken_options
         virtual void prepare() = 0;
         virtual void check() = 0;
 
-        virtual bool matches(const argument& arg)
+        virtual bool matches(const argument& arg) const
         {
             if (!arg.is_argument())
             {

--- a/include/nitro/broken_options/option/base.hpp
+++ b/include/nitro/broken_options/option/base.hpp
@@ -82,8 +82,8 @@ namespace broken_options
         std::ostream& format(std::ostream& s, int left_padding = 2) const
         {
             for (int i = 0; i < left_padding; ++i)
-                s << " ";
-            s << std::left << std::setw(38);
+                s << ' ';
+            s << std::left << std::setw(40 - left_padding);
 
             std::stringstream str;
 

--- a/include/nitro/broken_options/option/group.hpp
+++ b/include/nitro/broken_options/option/group.hpp
@@ -79,15 +79,15 @@ namespace broken_options
 
             for (auto& iter : options_)
             {
-                iter.second.format(s, position_);
+                iter.second.format(s, position_ * 2 + 2);
             }
             for (auto& iter : multi_options_)
             {
-                iter.second.format(s, position_);
+                iter.second.format(s, position_ * 2 + 2);
             }
             for (auto& iter : toggles_)
             {
-                iter.second.format(s, position_);
+                iter.second.format(s, position_ * 2 + 2);
             }
 
             for (auto& iter : sub_groups_)

--- a/include/nitro/broken_options/option/group.hpp
+++ b/include/nitro/broken_options/option/group.hpp
@@ -54,11 +54,6 @@ namespace broken_options
         {
         }
 
-        void add(base& option)
-        {
-            options_.emplace(option.name(), std::ref(option));
-        }
-
         group& subgroup(const std::string& name, const std::string& description = std::string(""))
         {
             if (std::count(sub_groups_.begin(), sub_groups_.end(), name) == 0)
@@ -166,6 +161,16 @@ namespace broken_options
                 tmp.insert(add.begin(), add.end());
             }
             return tmp;
+        }
+
+        bool operator==(const group& rhs)
+        {
+            return name == rhs.name;
+        }
+
+        bool operator==(const std::string& rhs)
+        {
+            return name == rhs;
         }
 
     private:

--- a/include/nitro/broken_options/option/group.hpp
+++ b/include/nitro/broken_options/option/group.hpp
@@ -92,7 +92,7 @@ namespace broken_options
         broken_options::option& option(const std::string& name,
                                        const std::string& description = std::string(""))
         {
-            if (all_argument_names_.count(name) > 0)
+            if (all_argument_names_.find(name) != all_argument_names_.end())
             {
                 auto search = options_.find(name);
                 if (search == options_.end())
@@ -116,7 +116,7 @@ namespace broken_options
         broken_options::multi_option& multi_option(const std::string& name,
                                                    const std::string& description = std::string(""))
         {
-            if (all_argument_names_.count(name) > 0)
+            if (all_argument_names_.find(name) != all_argument_names_.end())
             {
                 auto search = multi_options_.find(name);
                 if (search == multi_options_.end())
@@ -130,9 +130,9 @@ namespace broken_options
                 }
             }
 
+            all_argument_names_.emplace(name);
             multi_options_.emplace(std::piecewise_construct, std::forward_as_tuple(name),
                                    std::forward_as_tuple(name, description));
-            all_argument_names_.emplace(name);
 
             return multi_options_.at(name);
         }
@@ -140,7 +140,7 @@ namespace broken_options
         broken_options::toggle& toggle(const std::string& name,
                                        const std::string& description = std::string(""))
         {
-            if (all_argument_names_.count(name) > 0)
+            if (all_argument_names_.find(name) != all_argument_names_.end())
             {
                 auto search = toggles_.find(name);
                 if (search == toggles_.end())

--- a/include/nitro/broken_options/option/group.hpp
+++ b/include/nitro/broken_options/option/group.hpp
@@ -78,11 +78,11 @@ namespace broken_options
 
             std::map<std::string, const nitro::broken_options::base&> print_options;
             for (auto& it : options_)
-                print_options.emplace(it->first, it->second);
+                print_options.emplace(it.first, it.second);
             for (auto& it : multi_options_)
-                print_options.emplace(it->first, it->second);
+                print_options.emplace(it.first, it.second);
             for (auto& it : toggles_)
-                print_options.emplace(it->first, it->second);
+                print_options.emplace(it.first, it.second);
 
             for (auto& iter : print_options)
                 iter.second.format(s, level_ * 2 + 2);
@@ -164,7 +164,7 @@ namespace broken_options
         {
             std::map<std::string, broken_options::option&> tmp;
             for (auto& it : options_)
-                tmp.insert(it->first, it->second);
+                tmp.emplace(it.first, it.second);
 
             for (auto& sg : sub_groups_)
             {
@@ -178,7 +178,7 @@ namespace broken_options
         {
             std::map<std::string, broken_options::multi_option&> tmp;
             for (auto& it : multi_options_)
-                tmp.insert(it->first, it->second);
+                tmp.emplace(it.first, it.second);
 
             for (auto& sg : sub_groups_)
             {
@@ -192,7 +192,7 @@ namespace broken_options
         {
             std::map<std::string, broken_options::toggle&> tmp;
             for (auto& it : toggles_)
-                tmp.insert(it->first, it->second);
+                tmp.emplace(it.first, it.second);
 
             for (auto& sg : sub_groups_)
             {

--- a/include/nitro/broken_options/option/group.hpp
+++ b/include/nitro/broken_options/option/group.hpp
@@ -82,9 +82,15 @@ namespace broken_options
             {
                 iter.second.format(s);
             }
+
+            for (auto& iter : sub_groups_)
+            {
+                iter.usage(s);
+            }
         }
 
-        broken_options::option& option(const std::string& name, const std::string& description)
+        broken_options::option& option(const std::string& name,
+                                       const std::string& description = std::string(""))
         {
             if (all_argument_names_.count(name) > 0)
             {
@@ -99,7 +105,7 @@ namespace broken_options
         }
 
         broken_options::multi_option& multi_option(const std::string& name,
-                                                   const std::string& description)
+                                                   const std::string& description = std::string(""))
         {
             if (all_argument_names_.count(name) > 0)
             {
@@ -113,7 +119,8 @@ namespace broken_options
             return multi_options_.at(name);
         }
 
-        broken_options::toggle& toggle(const std::string& name, const std::string& description)
+        broken_options::toggle& toggle(const std::string& name,
+                                       const std::string& description = std::string(""))
         {
             if (all_argument_names_.count(name) > 0)
             {
@@ -175,12 +182,12 @@ namespace broken_options
             return tmp;
         }
 
-        bool operator==(const group& rhs)
+        bool operator==(const group& rhs) const
         {
             return name == rhs.name;
         }
 
-        bool operator==(const std::string& rhs)
+        bool operator==(const std::string& rhs) const
         {
             return name == rhs;
         }

--- a/include/nitro/broken_options/option/group.hpp
+++ b/include/nitro/broken_options/option/group.hpp
@@ -77,23 +77,16 @@ namespace broken_options
                 s << std::endl << description << std::endl << std::endl;
             }
 
+            std::map<std::string, const nitro::broken_options::base&> print_options;
             for (auto& iter : options_)
-            {
-                iter.second.format(s, position_ * 2 + 2);
-            }
+                print_options.emplace(iter.first, iter.second);
             for (auto& iter : multi_options_)
-            {
-                iter.second.format(s, position_ * 2 + 2);
-            }
+                print_options.emplace(iter.first, iter.second);
             for (auto& iter : toggles_)
-            {
-                iter.second.format(s, position_ * 2 + 2);
-            }
+                print_options.emplace(iter.first, iter.second);
 
-            for (auto& iter : sub_groups_)
-            {
-                iter.usage(s);
-            }
+            for (auto& iter : print_options)
+                iter.second.format(s, position_ * 2 + 2);
         }
 
         broken_options::option& option(const std::string& name,
@@ -168,9 +161,9 @@ namespace broken_options
             return toggles_.at(name);
         }
 
-        std::map<std::string, broken_options::option> get_all_options()
+        std::map<std::string, broken_options::option&> get_all_options()
         {
-            std::map<std::string, broken_options::option> tmp;
+            std::map<std::string, broken_options::option&> tmp;
             for (auto& it : options_)
             {
                 tmp.emplace(it.first, it.second);
@@ -184,9 +177,9 @@ namespace broken_options
             return tmp;
         }
 
-        std::map<std::string, broken_options::multi_option> get_all_multi_options()
+        std::map<std::string, broken_options::multi_option&> get_all_multi_options()
         {
-            std::map<std::string, broken_options::multi_option> tmp;
+            std::map<std::string, broken_options::multi_option&> tmp;
             for (auto& it : multi_options_)
             {
                 tmp.emplace(it.first, it.second);
@@ -200,9 +193,9 @@ namespace broken_options
             return tmp;
         }
 
-        std::map<std::string, broken_options::toggle> get_all_toggles()
+        std::map<std::string, broken_options::toggle&> get_all_toggles()
         {
-            std::map<std::string, broken_options::toggle> tmp;
+            std::map<std::string, broken_options::toggle&> tmp;
             for (auto& it : toggles_)
             {
                 tmp.emplace(it.first, it.second);

--- a/include/nitro/broken_options/option/group.hpp
+++ b/include/nitro/broken_options/option/group.hpp
@@ -94,7 +94,16 @@ namespace broken_options
         {
             if (all_argument_names_.count(name) > 0)
             {
-                raise<parser_error>("Trying to redefine argument name. Name: ", name);
+                auto search = options_.find(name);
+                if (search == options_.end())
+                {
+                    raise<parser_error>(
+                        "Trying to redefine argument name in a different group. Name: ", name);
+                }
+                else
+                {
+                    return search->second;
+                }
             }
 
             options_.emplace(std::piecewise_construct, std::forward_as_tuple(name),
@@ -109,7 +118,16 @@ namespace broken_options
         {
             if (all_argument_names_.count(name) > 0)
             {
-                raise<parser_error>("Trying to redefine argument name. Name: ", name);
+                auto search = multi_options_.find(name);
+                if (search == multi_options_.end())
+                {
+                    raise<parser_error>(
+                        "Trying to redefine argument name in a different group. Name: ", name);
+                }
+                else
+                {
+                    return search->second;
+                }
             }
 
             multi_options_.emplace(std::piecewise_construct, std::forward_as_tuple(name),
@@ -124,7 +142,16 @@ namespace broken_options
         {
             if (all_argument_names_.count(name) > 0)
             {
-                raise<parser_error>("Trying to redefine argument name. Name: ", name);
+                auto search = toggles_.find(name);
+                if (search == toggles_.end())
+                {
+                    raise<parser_error>(
+                        "Trying to redefine argument name in a different group. Name: ", name);
+                }
+                else
+                {
+                    return search->second;
+                }
             }
 
             toggles_.emplace(std::piecewise_construct, std::forward_as_tuple(name),

--- a/include/nitro/broken_options/option/group.hpp
+++ b/include/nitro/broken_options/option/group.hpp
@@ -48,39 +48,46 @@ namespace broken_options
         std::string description;
 
     public:
-        group(std::set<std::string>& all_argument_names, const std::string& name,
-              const std::string& description = std::string(""))
-        : name(name), description(description), all_argument_names_(all_argument_names)
+        group(std::set<std::string>& all_argument_names, const int& position,
+              const std::string& name, const std::string& description = std::string(""))
+        : name(name), description(description), all_argument_names_(all_argument_names),
+          position_(position)
         {
         }
 
         group& subgroup(const std::string& name, const std::string& description = std::string(""))
         {
             if (std::count(sub_groups_.begin(), sub_groups_.end(), name) == 0)
-                sub_groups_.emplace_back(group(all_argument_names_, name, description));
+                sub_groups_.emplace_back(
+                    group(all_argument_names_, position_ + 1, name, description));
 
             return *std::find(sub_groups_.begin(), sub_groups_.end(), name);
         }
 
         void usage(std::ostream& s) const
         {
+            s << std::endl;
+            for (int i = 0; i < position_; ++i)
+                s << "  ";
+
             s << name << ":" << std::endl;
-            if (description.size())
+
+            if (!description.empty())
             {
                 s << std::endl << description << std::endl << std::endl;
             }
 
             for (auto& iter : options_)
             {
-                iter.second.format(s);
+                iter.second.format(s, position_);
             }
             for (auto& iter : multi_options_)
             {
-                iter.second.format(s);
+                iter.second.format(s, position_);
             }
             for (auto& iter : toggles_)
             {
-                iter.second.format(s);
+                iter.second.format(s, position_);
             }
 
             for (auto& iter : sub_groups_)
@@ -161,9 +168,9 @@ namespace broken_options
             return toggles_.at(name);
         }
 
-        std::map<std::string, broken_options::option&> get_all_options()
+        std::map<std::string, broken_options::option> get_all_options()
         {
-            std::map<std::string, broken_options::option&> tmp;
+            std::map<std::string, broken_options::option> tmp;
             for (auto& it : options_)
             {
                 tmp.emplace(it.first, it.second);
@@ -177,9 +184,9 @@ namespace broken_options
             return tmp;
         }
 
-        std::map<std::string, broken_options::multi_option&> get_all_multi_options()
+        std::map<std::string, broken_options::multi_option> get_all_multi_options()
         {
-            std::map<std::string, broken_options::multi_option&> tmp;
+            std::map<std::string, broken_options::multi_option> tmp;
             for (auto& it : multi_options_)
             {
                 tmp.emplace(it.first, it.second);
@@ -193,9 +200,9 @@ namespace broken_options
             return tmp;
         }
 
-        std::map<std::string, broken_options::toggle&> get_all_toggles()
+        std::map<std::string, broken_options::toggle> get_all_toggles()
         {
-            std::map<std::string, broken_options::toggle&> tmp;
+            std::map<std::string, broken_options::toggle> tmp;
             for (auto& it : toggles_)
             {
                 tmp.emplace(it.first, it.second);
@@ -227,6 +234,7 @@ namespace broken_options
         std::map<std::string, broken_options::toggle> toggles_;
 
         std::vector<broken_options::group> sub_groups_;
+        int position_;
     };
 } // namespace broken_options
 } // namespace nitro

--- a/include/nitro/broken_options/option/group.hpp
+++ b/include/nitro/broken_options/option/group.hpp
@@ -57,7 +57,7 @@ namespace broken_options
 
         group& subgroup(const std::string& name, const std::string& description = std::string(""))
         {
-            if (std::count(sub_groups_.begin(), sub_groups_.end(), name) == 0)
+            if (std::find(sub_groups_.begin(), sub_groups_.end(), name) == sub_groups_.end())
                 sub_groups_.emplace_back(
                     group(all_argument_names_, position_ + 1, name, description));
 
@@ -106,11 +106,11 @@ namespace broken_options
                 }
             }
 
-            options_.emplace(std::piecewise_construct, std::forward_as_tuple(name),
-                             std::forward_as_tuple(name, description));
             all_argument_names_.emplace(name);
-
-            return options_.at(name);
+            return options_
+                .emplace(std::piecewise_construct, std::forward_as_tuple(name),
+                         std::forward_as_tuple(name, description))
+                .first->second;
         }
 
         broken_options::multi_option& multi_option(const std::string& name,
@@ -131,10 +131,10 @@ namespace broken_options
             }
 
             all_argument_names_.emplace(name);
-            multi_options_.emplace(std::piecewise_construct, std::forward_as_tuple(name),
-                                   std::forward_as_tuple(name, description));
-
-            return multi_options_.at(name);
+            return multi_options_
+                .emplace(std::piecewise_construct, std::forward_as_tuple(name),
+                         std::forward_as_tuple(name, description))
+                .first->second;
         }
 
         broken_options::toggle& toggle(const std::string& name,
@@ -154,11 +154,11 @@ namespace broken_options
                 }
             }
 
-            toggles_.emplace(std::piecewise_construct, std::forward_as_tuple(name),
-                             std::forward_as_tuple(name, description));
             all_argument_names_.emplace(name);
-
-            return toggles_.at(name);
+            return toggles_
+                .emplace(std::piecewise_construct, std::forward_as_tuple(name),
+                         std::forward_as_tuple(name, description))
+                .first->second;
         }
 
         std::map<std::string, broken_options::option&> get_all_options()

--- a/include/nitro/broken_options/option/group.hpp
+++ b/include/nitro/broken_options/option/group.hpp
@@ -130,7 +130,11 @@ namespace broken_options
         std::map<std::string, broken_options::option&> get_all_options()
         {
             std::map<std::string, broken_options::option&> tmp;
-            tmp.insert(options_.begin(), options_.end());
+            for (auto& it : options_)
+            {
+                tmp.emplace(it.first, it.second);
+            }
+
             for (auto& sg : sub_groups_)
             {
                 auto add = sg.get_all_options();
@@ -142,7 +146,11 @@ namespace broken_options
         std::map<std::string, broken_options::multi_option&> get_all_multi_options()
         {
             std::map<std::string, broken_options::multi_option&> tmp;
-            tmp.insert(multi_options_.begin(), multi_options_.end());
+            for (auto& it : multi_options_)
+            {
+                tmp.emplace(it.first, it.second);
+            }
+
             for (auto& sg : sub_groups_)
             {
                 auto add = sg.get_all_multi_options();
@@ -154,7 +162,11 @@ namespace broken_options
         std::map<std::string, broken_options::toggle&> get_all_toggles()
         {
             std::map<std::string, broken_options::toggle&> tmp;
-            tmp.insert(toggles_.begin(), toggles_.end());
+            for (auto& it : toggles_)
+            {
+                tmp.emplace(it.first, it.second);
+            }
+
             for (auto& sg : sub_groups_)
             {
                 auto add = sg.get_all_toggles();

--- a/include/nitro/broken_options/option/group.hpp
+++ b/include/nitro/broken_options/option/group.hpp
@@ -48,7 +48,7 @@ namespace broken_options
         std::string description;
 
     public:
-        group(std::set<std::string>& all_argument_names, const int& position,
+        group(std::set<std::string>& all_argument_names, int position,
               const std::string& name, const std::string& description = std::string(""))
         : name(name), description(description), all_argument_names_(all_argument_names),
           position_(position)

--- a/include/nitro/broken_options/option/group.hpp
+++ b/include/nitro/broken_options/option/group.hpp
@@ -41,8 +41,9 @@ namespace broken_options
     class group
     {
     public:
-        group(const std::string& name, const std::string& description = std::string(""))
-        : name_(name), description_(description)
+        group(std::set<std::string>& all_arguments, const std::string& name,
+              const std::string& description = std::string(""))
+        : name_(name), description_(description), all_arguments_(all_arguments)
         {
         }
 
@@ -68,7 +69,12 @@ namespace broken_options
     private:
         std::string name_;
         std::string description_;
-        std::map<std::string, std::reference_wrapper<base>> options_;
+
+        std::set<std::string>& all_arguments_;
+
+        std::map<std::string, broken_options::option> options_;
+        std::map<std::string, broken_options::multi_option> multi_options_;
+        std::map<std::string, broken_options::toggle> toggles_;
     };
 } // namespace broken_options
 } // namespace nitro

--- a/include/nitro/broken_options/option/group.hpp
+++ b/include/nitro/broken_options/option/group.hpp
@@ -77,9 +77,12 @@ namespace broken_options
             }
 
             std::map<std::string, const nitro::broken_options::base&> print_options;
-            print_options.emplace(options_.begin(), options_.end());
-            print_options.emplace(multi_options_.begin(), multi_options_.end());
-            print_options.emplace(toggles_.begin(), toggles_.end());
+            for (auto& it : options_)
+                print_options.emplace(it->first, it->second);
+            for (auto& it : multi_options_)
+                print_options.emplace(it->first, it->second);
+            for (auto& it : toggles_)
+                print_options.emplace(it->first, it->second);
 
             for (auto& iter : print_options)
                 iter.second.format(s, level_ * 2 + 2);
@@ -160,7 +163,8 @@ namespace broken_options
         std::map<std::string, broken_options::option&> get_all_options()
         {
             std::map<std::string, broken_options::option&> tmp;
-            tmp.insert(options_.begin(), options_.end());
+            for (auto& it : options_)
+                tmp.insert(it->first, it->second);
 
             for (auto& sg : sub_groups_)
             {
@@ -173,7 +177,8 @@ namespace broken_options
         std::map<std::string, broken_options::multi_option&> get_all_multi_options()
         {
             std::map<std::string, broken_options::multi_option&> tmp;
-            tmp.insert(multi_options_.begin(), multi_options_.end());
+            for (auto& it : multi_options_)
+                tmp.insert(it->first, it->second);
 
             for (auto& sg : sub_groups_)
             {
@@ -186,7 +191,8 @@ namespace broken_options
         std::map<std::string, broken_options::toggle&> get_all_toggles()
         {
             std::map<std::string, broken_options::toggle&> tmp;
-            tmp.insert(toggles_.begin(), toggles_.end());
+            for (auto& it : toggles_)
+                tmp.insert(it->first, it->second);
 
             for (auto& sg : sub_groups_)
             {

--- a/include/nitro/broken_options/option/toggle.hpp
+++ b/include/nitro/broken_options/option/toggle.hpp
@@ -158,7 +158,7 @@ namespace broken_options
             }
         }
 
-        bool matches(const argument& arg) override
+        bool matches(const argument& arg) const override
         {
             if (arg.is_named())
             {

--- a/include/nitro/broken_options/options.hpp
+++ b/include/nitro/broken_options/options.hpp
@@ -45,9 +45,9 @@ namespace broken_options
     class options
     {
     public:
-        options(const std::map<std::string, option>& option_map,
-                const std::map<std::string, multi_option>& multi_option_map,
-                const std::map<std::string, toggle>& toggle_map,
+        options(const std::map<std::string, option&>& option_map,
+                const std::map<std::string, multi_option&>& multi_option_map,
+                const std::map<std::string, toggle&>& toggle_map,
                 const std::vector<std::string>& positionals)
         : options_(option_map), multi_options_(multi_option_map), toggles_(toggle_map),
           positionals_(positionals)
@@ -115,9 +115,9 @@ namespace broken_options
         }
 
     private:
-        std::map<std::string, option> options_;
-        std::map<std::string, multi_option> multi_options_;
-        std::map<std::string, toggle> toggles_;
+        std::map<std::string, option&> options_;
+        std::map<std::string, multi_option&> multi_options_;
+        std::map<std::string, toggle&> toggles_;
         std::vector<std::string> positionals_;
     };
 } // namespace broken_options

--- a/include/nitro/broken_options/options.hpp
+++ b/include/nitro/broken_options/options.hpp
@@ -45,9 +45,9 @@ namespace broken_options
     class options
     {
     public:
-        options(const std::map<std::string, option&>& option_map,
-                const std::map<std::string, multi_option&>& multi_option_map,
-                const std::map<std::string, toggle&>& toggle_map,
+        options(const std::map<std::string, option>& option_map,
+                const std::map<std::string, multi_option>& multi_option_map,
+                const std::map<std::string, toggle>& toggle_map,
                 const std::vector<std::string>& positionals)
         : options_(option_map), multi_options_(multi_option_map), toggles_(toggle_map),
           positionals_(positionals)
@@ -115,9 +115,9 @@ namespace broken_options
         }
 
     private:
-        std::map<std::string, option&> options_;
-        std::map<std::string, multi_option&> multi_options_;
-        std::map<std::string, toggle&> toggles_;
+        std::map<std::string, option> options_;
+        std::map<std::string, multi_option> multi_options_;
+        std::map<std::string, toggle> toggles_;
         std::vector<std::string> positionals_;
     };
 } // namespace broken_options

--- a/include/nitro/broken_options/parser.hpp
+++ b/include/nitro/broken_options/parser.hpp
@@ -91,13 +91,17 @@ namespace broken_options
         std::map<std::string, nitro::broken_options::toggle> get_all_toggles();
 
         template <typename Iter>
-        bool parse_options(Iter& it, Iter end);
+        bool parse_options(Iter& it, Iter end,
+                           std::map<std::string, nitro::broken_options::option>& all_options);
 
         template <typename Iter>
-        bool parse_multi_options(Iter& it, Iter end);
+        bool parse_multi_options(
+            Iter& it, Iter end,
+            std::map<std::string, nitro::broken_options::multi_option>& all_multi_options);
 
         template <typename Iter>
-        bool parse_toggles(Iter& it, Iter end);
+        bool parse_toggles(Iter& it, Iter end,
+                           std::map<std::string, nitro::broken_options::toggle>& all_toggles);
 
         void prepare();
         void validate();

--- a/include/nitro/broken_options/parser.hpp
+++ b/include/nitro/broken_options/parser.hpp
@@ -86,9 +86,9 @@ namespace broken_options
     private:
         void check_consistency();
 
-        std::map<std::string, nitro::broken_options::option&> get_all_options() const;
-        std::map<std::string, nitro::broken_options::multi_option&> get_all_multi_options() const;
-        std::map<std::string, nitro::broken_options::toggle&> get_all_toggles() const;
+        std::map<std::string, nitro::broken_options::option&> get_all_options();
+        std::map<std::string, nitro::broken_options::multi_option&> get_all_multi_options();
+        std::map<std::string, nitro::broken_options::toggle&> get_all_toggles();
 
         template <typename Iter>
         bool parse_options(Iter& it, Iter end);

--- a/include/nitro/broken_options/parser.hpp
+++ b/include/nitro/broken_options/parser.hpp
@@ -56,7 +56,7 @@ namespace broken_options
         parser(const std::string& app_name = std::string("main"),
                const std::string& about = std::string(""))
         : app_name_(app_name), about_(about),
-          groups_({ nitro::broken_options::group(all_argument_names_, "arguments") }),
+          groups_({ nitro::broken_options::group(all_argument_names_, 0, "arguments") }),
           default_group_(groups_[0])
         {
         }
@@ -86,9 +86,9 @@ namespace broken_options
     private:
         void check_consistency();
 
-        std::map<std::string, nitro::broken_options::option&> get_all_options();
-        std::map<std::string, nitro::broken_options::multi_option&> get_all_multi_options();
-        std::map<std::string, nitro::broken_options::toggle&> get_all_toggles();
+        std::map<std::string, nitro::broken_options::option> get_all_options();
+        std::map<std::string, nitro::broken_options::multi_option> get_all_multi_options();
+        std::map<std::string, nitro::broken_options::toggle> get_all_toggles();
 
         template <typename Iter>
         bool parse_options(Iter& it, Iter end);

--- a/include/nitro/broken_options/parser.hpp
+++ b/include/nitro/broken_options/parser.hpp
@@ -38,6 +38,7 @@
 #include <nitro/broken_options/options.hpp>
 
 #include <nitro/except/raise.hpp>
+#include <nitro/lang/unordered.hpp>
 
 #include <iostream>
 #include <map>
@@ -54,13 +55,21 @@ namespace broken_options
     public:
         parser(const std::string& app_name = std::string("main"),
                const std::string& about = std::string(""))
-        : app_name_(app_name), about_(about), arguments_("arguments")
+        : app_name_(app_name), about_(about),
+          groups_({ nitro::broken_options::group(all_argument_names_, "arguments") }),
+          default_group_(groups_[0])
         {
         }
 
         auto parse(int argc, const char* const argv[]) -> options;
 
     public:
+        nitro::broken_options::group& group(const std::string& name,
+                                            const std::string& description = std::string(""));
+        nitro::broken_options::group&
+        default_group(const std::string& name = std::string(""),
+                      const std::string& description = std::string(""));
+
         auto option(const std::string& name, const std::string& description = std::string(""))
             -> broken_options::option&;
         auto multi_option(const std::string& name, const std::string& description = std::string(""))
@@ -76,6 +85,10 @@ namespace broken_options
 
     private:
         void check_consistency();
+
+        std::map<std::string, nitro::broken_options::option&> get_all_options() const;
+        std::map<std::string, nitro::broken_options::multi_option&> get_all_multi_options() const;
+        std::map<std::string, nitro::broken_options::toggle&> get_all_toggles() const;
 
         template <typename Iter>
         bool parse_options(Iter& it, Iter end);
@@ -96,11 +109,10 @@ namespace broken_options
         std::string app_name_;
         std::string about_;
 
-        std::map<std::string, broken_options::option> options_;
-        std::map<std::string, broken_options::multi_option> multi_options_;
-        std::map<std::string, broken_options::toggle> toggles_;
+        std::set<std::string> all_argument_names_;
+        std::vector<nitro::broken_options::group> groups_;
 
-        group arguments_;
+        nitro::broken_options::group& default_group_;
 
         std::size_t allowed_positionals_ = 0;
         std::string positional_name_ = "args";

--- a/include/nitro/broken_options/parser.hpp
+++ b/include/nitro/broken_options/parser.hpp
@@ -40,10 +40,10 @@
 #include <nitro/except/raise.hpp>
 #include <nitro/lang/unordered.hpp>
 
+#include <deque>
 #include <iostream>
 #include <map>
 #include <string>
-#include <vector>
 
 namespace nitro
 {
@@ -57,7 +57,7 @@ namespace broken_options
                const std::string& about = std::string(""))
         : app_name_(app_name), about_(about),
           groups_({ nitro::broken_options::group(all_argument_names_, 0, "arguments") }),
-          default_group_(groups_[0])
+          default_group_(groups_.front())
         {
         }
 
@@ -86,9 +86,9 @@ namespace broken_options
     private:
         void check_consistency();
 
-        std::map<std::string, nitro::broken_options::option> get_all_options();
-        std::map<std::string, nitro::broken_options::multi_option> get_all_multi_options();
-        std::map<std::string, nitro::broken_options::toggle> get_all_toggles();
+        std::map<std::string, nitro::broken_options::option&> get_all_options();
+        std::map<std::string, nitro::broken_options::multi_option&> get_all_multi_options();
+        std::map<std::string, nitro::broken_options::toggle&> get_all_toggles();
 
         template <typename Iter>
         bool parse_options(Iter& it, Iter end);
@@ -110,11 +110,7 @@ namespace broken_options
         std::string about_;
 
         std::set<std::string> all_argument_names_;
-        std::vector<nitro::broken_options::group> groups_;
-
-        std::map<std::string, broken_options::option> options_;
-        std::map<std::string, broken_options::multi_option> multi_options_;
-        std::map<std::string, broken_options::toggle> toggles_;
+        std::deque<nitro::broken_options::group> groups_;
 
         nitro::broken_options::group& default_group_;
 

--- a/include/nitro/broken_options/parser.hpp
+++ b/include/nitro/broken_options/parser.hpp
@@ -91,17 +91,13 @@ namespace broken_options
         std::map<std::string, nitro::broken_options::toggle> get_all_toggles();
 
         template <typename Iter>
-        bool parse_options(Iter& it, Iter end,
-                           std::map<std::string, nitro::broken_options::option>& all_options);
+        bool parse_options(Iter& it, Iter end);
 
         template <typename Iter>
-        bool parse_multi_options(
-            Iter& it, Iter end,
-            std::map<std::string, nitro::broken_options::multi_option>& all_multi_options);
+        bool parse_multi_options(Iter& it, Iter end);
 
         template <typename Iter>
-        bool parse_toggles(Iter& it, Iter end,
-                           std::map<std::string, nitro::broken_options::toggle>& all_toggles);
+        bool parse_toggles(Iter& it, Iter end);
 
         void prepare();
         void validate();
@@ -115,6 +111,10 @@ namespace broken_options
 
         std::set<std::string> all_argument_names_;
         std::vector<nitro::broken_options::group> groups_;
+
+        std::map<std::string, broken_options::option> options_;
+        std::map<std::string, broken_options::multi_option> multi_options_;
+        std::map<std::string, broken_options::toggle> toggles_;
 
         nitro::broken_options::group& default_group_;
 

--- a/include/nitro/broken_options/parser.hpp
+++ b/include/nitro/broken_options/parser.hpp
@@ -38,7 +38,6 @@
 #include <nitro/broken_options/options.hpp>
 
 #include <nitro/except/raise.hpp>
-#include <nitro/lang/unordered.hpp>
 
 #include <deque>
 #include <iostream>

--- a/include/nitro/broken_options/parser.ipp
+++ b/include/nitro/broken_options/parser.ipp
@@ -39,9 +39,9 @@ namespace nitro
 {
 namespace broken_options
 {
-    std::map<std::string, broken_options::option&> parser::get_all_options()
+    std::map<std::string, broken_options::option> parser::get_all_options()
     {
-        std::map<std::string, broken_options::option&> tmp;
+        std::map<std::string, broken_options::option> tmp;
         for (auto& sg : groups_)
         {
             auto add = sg.get_all_options();
@@ -50,9 +50,9 @@ namespace broken_options
         return tmp;
     }
 
-    std::map<std::string, broken_options::multi_option&> parser::get_all_multi_options()
+    std::map<std::string, broken_options::multi_option> parser::get_all_multi_options()
     {
-        std::map<std::string, broken_options::multi_option&> tmp;
+        std::map<std::string, broken_options::multi_option> tmp;
         for (auto& sg : groups_)
         {
             auto add = sg.get_all_multi_options();
@@ -61,9 +61,9 @@ namespace broken_options
         return tmp;
     }
 
-    std::map<std::string, broken_options::toggle&> parser::get_all_toggles()
+    std::map<std::string, broken_options::toggle> parser::get_all_toggles()
     {
-        std::map<std::string, broken_options::toggle&> tmp;
+        std::map<std::string, broken_options::toggle> tmp;
         for (auto& sg : groups_)
         {
             auto add = sg.get_all_toggles();
@@ -78,12 +78,14 @@ namespace broken_options
         for (nitro::broken_options::group& grp : groups_)
         {
             if (grp.name == name)
+            {
                 if (!description.empty())
                     grp.description = description;
-            return grp;
+                return grp;
+            }
         }
 
-        groups_.emplace_back(group(name, description));
+        groups_.emplace_back(broken_options::group(all_argument_names_, 0, name, description));
         return groups_.back();
     }
     nitro::broken_options::group& parser::default_group(const std::string& name,
@@ -134,6 +136,10 @@ namespace broken_options
 
         argument_parser args(argc, argv);
 
+        auto all_options = get_all_options();
+        auto all_multi_options = get_all_multi_options();
+        auto all_toggles = get_all_toggles();
+
         for (auto it = args.begin(); it != args.end(); ++it)
         {
             if (only_positionals || it->is_value())
@@ -176,7 +182,7 @@ namespace broken_options
 
         validate();
 
-        return options(get_all_options(), get_all_multi_options(), get_all_toggles(), positionals);
+        return options(all_options, all_multi_options, all_toggles, positionals);
     }
 
     std::ostream& parser::usage(std::ostream& s, bool print_default_group)
@@ -248,7 +254,7 @@ namespace broken_options
     template <typename Iter>
     bool parser::parse_options(Iter& it, Iter end)
     {
-        for (const auto& option : get_all_options())
+        for (auto& option : get_all_options())
         {
 
             if (it->has_value())
@@ -286,7 +292,7 @@ namespace broken_options
     template <typename Iter>
     bool parser::parse_multi_options(Iter& it, Iter end)
     {
-        for (const auto& option : get_all_multi_options())
+        for (auto& option : get_all_multi_options())
         {
             if (it->has_value())
             {
@@ -326,7 +332,7 @@ namespace broken_options
 
         bool match_found = false;
 
-        for (const auto& option : get_all_toggles())
+        for (auto& option : get_all_toggles())
         {
             if (option.second.matches(it->name()))
             {
@@ -370,17 +376,17 @@ namespace broken_options
     template <typename F>
     void parser::for_each_option(F f)
     {
-        for (const auto& option : get_all_options())
+        for (auto& option : get_all_options())
         {
             f(option.second);
         }
 
-        for (const auto& option : get_all_multi_options())
+        for (auto& option : get_all_multi_options())
         {
             f(option.second);
         }
 
-        for (const auto& option : get_all_toggles())
+        for (auto& option : get_all_toggles())
         {
             f(option.second);
         }

--- a/include/nitro/broken_options/parser.ipp
+++ b/include/nitro/broken_options/parser.ipp
@@ -39,9 +39,9 @@ namespace nitro
 {
 namespace broken_options
 {
-    std::map<std::string, broken_options::option> parser::get_all_options()
+    std::map<std::string, broken_options::option&> parser::get_all_options()
     {
-        std::map<std::string, broken_options::option> tmp;
+        std::map<std::string, broken_options::option&> tmp;
         for (auto& sg : groups_)
         {
             auto add = sg.get_all_options();
@@ -50,9 +50,9 @@ namespace broken_options
         return tmp;
     }
 
-    std::map<std::string, broken_options::multi_option> parser::get_all_multi_options()
+    std::map<std::string, broken_options::multi_option&> parser::get_all_multi_options()
     {
-        std::map<std::string, broken_options::multi_option> tmp;
+        std::map<std::string, broken_options::multi_option&> tmp;
         for (auto& sg : groups_)
         {
             auto add = sg.get_all_multi_options();
@@ -61,9 +61,9 @@ namespace broken_options
         return tmp;
     }
 
-    std::map<std::string, broken_options::toggle> parser::get_all_toggles()
+    std::map<std::string, broken_options::toggle&> parser::get_all_toggles()
     {
-        std::map<std::string, broken_options::toggle> tmp;
+        std::map<std::string, broken_options::toggle&> tmp;
         for (auto& sg : groups_)
         {
             auto add = sg.get_all_toggles();
@@ -136,10 +136,6 @@ namespace broken_options
 
         argument_parser args(argc, argv);
 
-        options_ = std::move(get_all_options());
-        multi_options_ = std::move(get_all_multi_options());
-        toggles_ = std::move(get_all_toggles());
-
         for (auto it = args.begin(); it != args.end(); ++it)
         {
             if (only_positionals || it->is_value())
@@ -178,7 +174,7 @@ namespace broken_options
 
         validate();
 
-        return options(options_, multi_options_, toggles_, positionals);
+        return options(get_all_options(), get_all_multi_options(), get_all_toggles(), positionals);
     }
 
     std::ostream& parser::usage(std::ostream& s, bool print_default_group)
@@ -238,19 +234,22 @@ namespace broken_options
             s << about_ << std::endl << std::endl;
         }
 
-        if (print_default_group)
+        bool first = true;
+        for (const auto& grp : groups_)
         {
-            for (const auto& grp : groups_)
+            if (print_default_group || !first)
                 grp.usage(s);
-        }
 
+            if (first)
+                first = false;
+        }
         return s;
     }
 
     template <typename Iter>
     bool parser::parse_options(Iter& it, Iter end)
     {
-        for (auto& option : options_)
+        for (auto& option : get_all_options())
         {
 
             if (it->has_value())
@@ -288,7 +287,7 @@ namespace broken_options
     template <typename Iter>
     bool parser::parse_multi_options(Iter& it, Iter end)
     {
-        for (auto& option : multi_options_)
+        for (auto& option : get_all_multi_options())
         {
             if (it->has_value())
             {
@@ -328,7 +327,7 @@ namespace broken_options
 
         bool match_found = false;
 
-        for (auto& option : toggles_)
+        for (auto& option : get_all_toggles())
         {
             if (option.second.matches(it->name()))
             {
@@ -372,17 +371,17 @@ namespace broken_options
     template <typename F>
     void parser::for_each_option(F f)
     {
-        for (auto& option : options_)
+        for (auto& option : get_all_options())
         {
             f(option.second);
         }
 
-        for (auto& option : multi_options_)
+        for (auto& option : get_all_multi_options())
         {
             f(option.second);
         }
 
-        for (auto& option : toggles_)
+        for (auto& option : get_all_toggles())
         {
             f(option.second);
         }

--- a/include/nitro/broken_options/parser.ipp
+++ b/include/nitro/broken_options/parser.ipp
@@ -161,12 +161,9 @@ namespace broken_options
                 continue;
             }
 
-            if (parse_options(it, args.end()) || parse_multi_options(it, args.end()))
-            {
-                continue;
-            }
-
-            if (parse_toggles(it, args.end()))
+            if (parse_options(it, args.end(), all_options) ||
+                parse_multi_options(it, args.end(), all_multi_options) ||
+                parse_toggles(it, args.end(), all_toggles))
             {
                 continue;
             }
@@ -252,9 +249,10 @@ namespace broken_options
     }
 
     template <typename Iter>
-    bool parser::parse_options(Iter& it, Iter end)
+    bool parser::parse_options(Iter& it, Iter end,
+                               std::map<std::string, nitro::broken_options::option>& all_options)
     {
-        for (auto& option : get_all_options())
+        for (auto& option : all_options)
         {
 
             if (it->has_value())
@@ -290,9 +288,11 @@ namespace broken_options
     }
 
     template <typename Iter>
-    bool parser::parse_multi_options(Iter& it, Iter end)
+    bool parser::parse_multi_options(
+        Iter& it, Iter end,
+        std::map<std::string, nitro::broken_options::multi_option>& all_multi_options)
     {
-        for (auto& option : get_all_multi_options())
+        for (auto& option : all_multi_options)
         {
             if (it->has_value())
             {
@@ -326,13 +326,14 @@ namespace broken_options
     }
 
     template <typename Iter>
-    bool parser::parse_toggles(Iter& it, Iter end)
+    bool parser::parse_toggles(Iter& it, Iter end,
+                               std::map<std::string, nitro::broken_options::toggle>& all_toggles)
     {
         (void)end;
 
         bool match_found = false;
 
-        for (auto& option : get_all_toggles())
+        for (auto& option : all_toggles)
         {
             if (option.second.matches(it->name()))
             {

--- a/include/nitro/broken_options/parser.ipp
+++ b/include/nitro/broken_options/parser.ipp
@@ -136,9 +136,9 @@ namespace broken_options
 
         argument_parser args(argc, argv);
 
-        auto all_options = get_all_options();
-        auto all_multi_options = get_all_multi_options();
-        auto all_toggles = get_all_toggles();
+        options_ = std::move(get_all_options());
+        multi_options_ = std::move(get_all_multi_options());
+        toggles_ = std::move(get_all_toggles());
 
         for (auto it = args.begin(); it != args.end(); ++it)
         {
@@ -161,9 +161,8 @@ namespace broken_options
                 continue;
             }
 
-            if (parse_options(it, args.end(), all_options) ||
-                parse_multi_options(it, args.end(), all_multi_options) ||
-                parse_toggles(it, args.end(), all_toggles))
+            if (parse_options(it, args.end()) || parse_multi_options(it, args.end()) ||
+                parse_toggles(it, args.end()))
             {
                 continue;
             }
@@ -179,7 +178,7 @@ namespace broken_options
 
         validate();
 
-        return options(all_options, all_multi_options, all_toggles, positionals);
+        return options(options_, multi_options_, toggles_, positionals);
     }
 
     std::ostream& parser::usage(std::ostream& s, bool print_default_group)
@@ -249,10 +248,9 @@ namespace broken_options
     }
 
     template <typename Iter>
-    bool parser::parse_options(Iter& it, Iter end,
-                               std::map<std::string, nitro::broken_options::option>& all_options)
+    bool parser::parse_options(Iter& it, Iter end)
     {
-        for (auto& option : all_options)
+        for (auto& option : options_)
         {
 
             if (it->has_value())
@@ -288,11 +286,9 @@ namespace broken_options
     }
 
     template <typename Iter>
-    bool parser::parse_multi_options(
-        Iter& it, Iter end,
-        std::map<std::string, nitro::broken_options::multi_option>& all_multi_options)
+    bool parser::parse_multi_options(Iter& it, Iter end)
     {
-        for (auto& option : all_multi_options)
+        for (auto& option : multi_options_)
         {
             if (it->has_value())
             {
@@ -326,14 +322,13 @@ namespace broken_options
     }
 
     template <typename Iter>
-    bool parser::parse_toggles(Iter& it, Iter end,
-                               std::map<std::string, nitro::broken_options::toggle>& all_toggles)
+    bool parser::parse_toggles(Iter& it, Iter end)
     {
         (void)end;
 
         bool match_found = false;
 
-        for (auto& option : all_toggles)
+        for (auto& option : toggles_)
         {
             if (option.second.matches(it->name()))
             {
@@ -377,21 +372,20 @@ namespace broken_options
     template <typename F>
     void parser::for_each_option(F f)
     {
-        for (auto& option : get_all_options())
+        for (auto& option : options_)
         {
             f(option.second);
         }
 
-        for (auto& option : get_all_multi_options())
+        for (auto& option : multi_options_)
         {
             f(option.second);
         }
 
-        for (auto& option : get_all_toggles())
+        for (auto& option : toggles_)
         {
             f(option.second);
         }
     }
-
 } // namespace broken_options
 } // namespace nitro

--- a/include/nitro/broken_options/parser.ipp
+++ b/include/nitro/broken_options/parser.ipp
@@ -78,7 +78,7 @@ namespace broken_options
         for (nitro::broken_options::group& grp : groups_)
         {
             if (grp.name == name)
-                if (description.length())
+                if (!description.empty())
                     grp.description = description;
             return grp;
         }
@@ -89,9 +89,9 @@ namespace broken_options
     nitro::broken_options::group& parser::default_group(const std::string& name,
                                                         const std::string& description)
     {
-        if (name.length())
+        if (!name.empty())
             default_group_.name = name;
-        if (description.length())
+        if (!description.empty())
             default_group_.description = description;
 
         return default_group_;

--- a/tests/broken_options_test.cpp
+++ b/tests/broken_options_test.cpp
@@ -550,10 +550,15 @@ test arguments:
 
         std::stringstream s;
 
-        auto grp1 = parser.group("group1");
-        auto grp2 = parser.group("group1");
+        auto& grp1 = parser.group("group1");
+        auto& grp2 = parser.group("group1");
 
         REQUIRE(grp1 == grp2);
+
+        auto& opt1 = grp1.option("opt");
+        auto& opt2 = grp2.option("opt");
+
+        REQUIRE(&opt1 == &opt2);
     }
 }
 

--- a/tests/broken_options_test.cpp
+++ b/tests/broken_options_test.cpp
@@ -1302,6 +1302,7 @@ TEST_CASE("Usage metavar work")
 
 about
 
+
 arguments:
   --opt_nosd test                         some opt without short and default
 )EXPECTED");
@@ -1321,6 +1322,7 @@ arguments:
                 R"EXPECTED(usage: app_name --mopt
 
 about
+
 
 arguments:
   --mopt test                             some multi opt

--- a/tests/broken_options_test.cpp
+++ b/tests/broken_options_test.cpp
@@ -265,107 +265,7 @@ arguments:
 
 TEST_CASE("Groups")
 {
-    SECTION("Groups output is correct")
-    {
-        nitro::broken_options::parser parser("app_name", "about");
-
-        std::stringstream s;
-
-        parser.accept_positionals(3);
-        parser.positional_name("command line");
-
-        parser.group("group1").toggle("tog", "some toggle").short_name("t");
-        parser.group("group1").toggle("togg", "some other toggle").short_name("u");
-
-        parser.group("group1").option("opt", "some opt").short_name("o");
-        parser.group("group1")
-            .option("opt_with_d", "some opt with a default")
-            .short_name("d")
-            .default_value("default value");
-
-        parser.group("group1")
-            .option("opt_nos", "some opt without a short, but a default")
-            .default_value("default value");
-        parser.group("group1").option("opt_nosd", "some opt without short and default");
-
-        parser.group("group1").option(
-            "opt_long", "an option with an very very very very very very very very very "
-                        "very very very very very very very very very very very very very "
-                        "very very very very very very very very long description");
-
-        parser.group("group2")
-            .option("some_long_named_option",
-                    "an option with an very very very very very very very very very "
-                    "very very very very very very very very very very very very very "
-                    "very very very very very very very very long description")
-            .short_name("x")
-            .default_value("some very long default parameter for this fucking thing");
-
-        parser.group("group2").multi_option("mopt", "some multi opt").short_name("m");
-
-        parser.group("group2")
-            .option("env-opt", "This is an option to set cool stuff.")
-            .env("ENV_OPT");
-        parser.group("group2").option("env-opt-2").env("ENV_OPT2");
-
-        parser.usage(s, false);
-
-        auto actual = s.str();
-        std::string expected =
-            R"EXPECTED(usage: app_name [-tu] --env-opt --env-opt-2 --opt --opt_long [--opt_nos] --opt_nosd [--opt_with_d] [--some_long_named_option] --mopt [command line ...]
-
-about
-
-
-group1:
-  -o [ --opt ] arg                        some opt
-  --opt_long arg                          an option with an very very very very
-                                          very very very very very very very
-                                          very very very very very very very
-                                          very very very very very very very
-                                          very very very very very long
-                                          description
-  --opt_nos [=default value]              some opt without a short, but a
-                                          default
-  --opt_nosd arg                          some opt without short and default
-  -d [ --opt_with_d ] [=default value]    some opt with a default
-  -t [ --tog ]                            some toggle
-  -u [ --togg ]                           some other toggle
-
-group2:
-  --env-opt arg                           This is an option to set cool stuff.
-                                          Can be set using the environment
-                                          variable 'ENV_OPT'.
-  --env-opt-2 arg                         Can be set using the environment
-                                          variable 'ENV_OPT2'.
-  -m [ --mopt ] arg                       some multi opt
-  -x [ --some_long_named_option ] [=some very long default parameter for this fucking thing]
-                                          an option with an very very very very
-                                          very very very very very very very
-                                          very very very very very very very
-                                          very very very very very very very
-                                          very very very very very long
-                                          description
-)EXPECTED";
-
-        CHECK(actual.size() == expected.size());
-
-        std::size_t tmp = 0;
-        for (unsigned long i = 0; i < actual.size(); ++i)
-        {
-            if (actual[i] != expected[i])
-            {
-                std::cout << i << " " << actual[i] << " " << expected[i] << std::endl;
-                ++tmp;
-                if (tmp > 100)
-                    break;
-            }
-        }
-
-        REQUIRE(actual == expected);
-    }
-
-    SECTION("Groups output is correct #2")
+    SECTION("Usage output with groups is correct")
     {
         nitro::broken_options::parser parser("app_name", "about");
 
@@ -387,11 +287,12 @@ group2:
 
         grp1.option("opt_nos", "some opt without a short, but a default")
             .default_value("default value");
-        grp1.option("opt_nosd", "some opt without short and default");
+        parser.group("group1").option("opt_nosd", "some opt without short and default");
 
-        grp1.option("opt_long", "an option with an very very very very very very very very very "
-                                "very very very very very very very very very very very very very "
-                                "very very very very very very very very long description");
+        parser.group("group1").option(
+            "opt_long", "an option with an very very very very very very very very very "
+                        "very very very very very very very very very very very very very "
+                        "very very very very very very very very long description");
 
         grp2.option("some_long_named_option",
                     "an option with an very very very very very very very very very "
@@ -402,8 +303,10 @@ group2:
 
         grp2.multi_option("mopt", "some multi opt").short_name("m");
 
-        grp2.option("env-opt", "This is an option to set cool stuff.").env("ENV_OPT");
-        grp2.option("env-opt-2").env("ENV_OPT2");
+        parser.group("group2")
+            .option("env-opt", "This is an option to set cool stuff.")
+            .env("ENV_OPT");
+        parser.group("group2").option("env-opt-2").env("ENV_OPT2");
 
         parser.usage(s, false);
 
@@ -467,80 +370,20 @@ group2:
 
     SECTION("Change name of default group should work")
     {
-        nitro::broken_options::parser parser("app_name", "about");
+        nitro::broken_options::parser parser("app_name", "");
 
         std::stringstream s;
 
         parser.default_group("test arguments");
-        parser.accept_positionals(3);
-        parser.positional_name("command line");
-
         parser.toggle("tog", "some toggle").short_name("t");
-        parser.toggle("togg", "some other toggle").short_name("u");
-
-        parser.option("opt", "some opt").short_name("o");
-        parser.option("opt_with_d", "some opt with a default")
-            .short_name("d")
-            .default_value("default value");
-
-        parser.option("opt_nos", "some opt without a short, but a default")
-            .default_value("default value");
-        parser.option("opt_nosd", "some opt without short and default");
-
-        parser.option("opt_long",
-                      "an option with an very very very very very very very very very "
-                      "very very very very very very very very very very very very very "
-                      "very very very very very very very very long description");
-
-        parser
-            .option("some_long_named_option",
-                    "an option with an very very very very very very very very very "
-                    "very very very very very very very very very very very very very "
-                    "very very very very very very very very long description")
-            .short_name("x")
-            .default_value("some very long default parameter for this fucking thing");
-
-        parser.multi_option("mopt", "some multi opt").short_name("m");
-
-        parser.option("env-opt", "This is an option to set cool stuff.").env("ENV_OPT");
-        parser.option("env-opt-2").env("ENV_OPT2");
-
         parser.usage(s);
 
-        REQUIRE(
-            s.str() ==
-            R"EXPECTED(usage: app_name [-tu] --env-opt --env-opt-2 --opt --opt_long [--opt_nos] --opt_nosd [--opt_with_d] [--some_long_named_option] --mopt [command line ...]
-
-about
+        REQUIRE(s.str() ==
+                R"EXPECTED(usage: app_name [-t]
 
 
 test arguments:
-  --env-opt arg                           This is an option to set cool stuff.
-                                          Can be set using the environment
-                                          variable 'ENV_OPT'.
-  --env-opt-2 arg                         Can be set using the environment
-                                          variable 'ENV_OPT2'.
-  -m [ --mopt ] arg                       some multi opt
-  -o [ --opt ] arg                        some opt
-  --opt_long arg                          an option with an very very very very
-                                          very very very very very very very
-                                          very very very very very very very
-                                          very very very very very very very
-                                          very very very very very long
-                                          description
-  --opt_nos [=default value]              some opt without a short, but a
-                                          default
-  --opt_nosd arg                          some opt without short and default
-  -d [ --opt_with_d ] [=default value]    some opt with a default
-  -x [ --some_long_named_option ] [=some very long default parameter for this fucking thing]
-                                          an option with an very very very very
-                                          very very very very very very very
-                                          very very very very very very very
-                                          very very very very very very very
-                                          very very very very very long
-                                          description
   -t [ --tog ]                            some toggle
-  -u [ --togg ]                           some other toggle
 )EXPECTED");
     }
 

--- a/tests/broken_options_test.cpp
+++ b/tests/broken_options_test.cpp
@@ -247,18 +247,6 @@ arguments:
 
         CHECK(actual.size() == expected.size());
 
-        std::size_t tmp = 0;
-        for (unsigned long i = 0; i < actual.size(); ++i)
-        {
-            if (actual[i] != expected[i])
-            {
-                std::cout << i << " " << actual[i] << " " << expected[i] << std::endl;
-                ++tmp;
-                if (tmp > 100)
-                    break;
-            }
-        }
-
         REQUIRE(actual == expected);
     }
 }
@@ -352,18 +340,6 @@ group2:
 )EXPECTED";
 
         CHECK(actual.size() == expected.size());
-
-        std::size_t tmp = 0;
-        for (unsigned long i = 0; i < actual.size(); ++i)
-        {
-            if (actual[i] != expected[i])
-            {
-                std::cout << i << " " << actual[i] << " " << expected[i] << std::endl;
-                ++tmp;
-                if (tmp > 100)
-                    break;
-            }
-        }
 
         REQUIRE(actual == expected);
     }

--- a/tests/broken_options_test.cpp
+++ b/tests/broken_options_test.cpp
@@ -263,9 +263,9 @@ arguments:
     }
 }
 
-TEST_CASE("Groups work")
+TEST_CASE("Groups")
 {
-    SECTION("Groups work")
+    SECTION("Groups output is correct")
     {
         nitro::broken_options::parser parser("app_name", "about");
 
@@ -365,7 +365,7 @@ group2:
         REQUIRE(actual == expected);
     }
 
-    SECTION("Groups work 2")
+    SECTION("Groups output is correct #2")
     {
         nitro::broken_options::parser parser("app_name", "about");
 
@@ -465,7 +465,7 @@ group2:
         REQUIRE(actual == expected);
     }
 
-    SECTION("Change Default Group")
+    SECTION("Change name of default group should work")
     {
         nitro::broken_options::parser parser("app_name", "about");
 
@@ -544,20 +544,7 @@ test arguments:
 )EXPECTED");
     }
 
-    SECTION("Multiple groups with same name should be one group")
-    {
-        nitro::broken_options::parser parser("app_name", "about");
-
-        std::stringstream s;
-
-        auto grp1 = parser.group("group1");
-        auto grp2 = parser.group("group2");
-
-        grp1.toggle("tog", "should work");
-        REQUIRE_THROWS_AS(grp2.toggle("tog", "should fail"), nitro::broken_options::parser_error);
-    }
-
-    SECTION("Groups work 2")
+    SECTION("Getting group with same name")
     {
         nitro::broken_options::parser parser("app_name", "about");
 

--- a/tests/broken_options_test.cpp
+++ b/tests/broken_options_test.cpp
@@ -64,12 +64,14 @@ TEST_CASE("Usage descriptions work")
 
 about
 
+
 arguments:
   --env-opt arg                           This is an option to set cool stuff.
                                           Can be set using the environment
                                           variable 'ENV_OPT'.
   --env-opt-2 arg                         Can be set using the environment
                                           variable 'ENV_OPT2'.
+  -m [ --mopt ] arg                       some multi opt
   -o [ --opt ] arg                        some opt
   --opt_long arg                          an option with an very very very very
                                           very very very very very very very
@@ -88,7 +90,6 @@ arguments:
                                           very very very very very very very
                                           very very very very very long
                                           description
-  -m [ --mopt ] arg                       some multi opt
   -t [ --tog ]                            some toggle
   -u [ --togg ]                           some other toggle
 )EXPECTED";
@@ -156,13 +157,14 @@ TEST_CASE("Groups work")
             .env("ENV_OPT");
         parser.group("group2").option("env-opt-2").env("ENV_OPT2");
 
-        parser.usage(s);
+        parser.usage(s, false);
 
         auto actual = s.str();
         std::string expected =
             R"EXPECTED(usage: app_name [-tu] --env-opt --env-opt-2 --opt --opt_long [--opt_nos] --opt_nosd [--opt_with_d] [--some_long_named_option] --mopt [command line ...]
 
 about
+
 
 group1:
   -o [ --opt ] arg                        some opt
@@ -252,13 +254,14 @@ group2:
         grp2.option("env-opt", "This is an option to set cool stuff.").env("ENV_OPT");
         grp2.option("env-opt-2").env("ENV_OPT2");
 
-        parser.usage(s);
+        parser.usage(s, false);
 
         auto actual = s.str();
         std::string expected =
             R"EXPECTED(usage: app_name [-tu] --env-opt --env-opt-2 --opt --opt_long [--opt_nos] --opt_nosd [--opt_with_d] [--some_long_named_option] --mopt [command line ...]
 
 about
+
 
 group1:
 
@@ -359,12 +362,14 @@ group2:
 
 about
 
+
 test arguments:
   --env-opt arg                           This is an option to set cool stuff.
                                           Can be set using the environment
                                           variable 'ENV_OPT'.
   --env-opt-2 arg                         Can be set using the environment
                                           variable 'ENV_OPT2'.
+  -m [ --mopt ] arg                       some multi opt
   -o [ --opt ] arg                        some opt
   --opt_long arg                          an option with an very very very very
                                           very very very very very very very
@@ -383,7 +388,6 @@ test arguments:
                                           very very very very very very very
                                           very very very very very long
                                           description
-  -m [ --mopt ] arg                       some multi opt
   -t [ --tog ]                            some toggle
   -u [ --togg ]                           some other toggle
 )EXPECTED");

--- a/tests/broken_options_test.cpp
+++ b/tests/broken_options_test.cpp
@@ -221,8 +221,8 @@ group2:
         parser.accept_positionals(3);
         parser.positional_name("command line");
 
-        auto grp1 = parser.group("group1", "some text");
-        auto grp2 = parser.group("group2");
+        auto& grp1 = parser.group("group1", "some text");
+        auto& grp2 = parser.group("group2");
 
         grp1.toggle("tog", "some toggle").short_name("t");
         grp1.toggle("togg", "some other toggle").short_name("u");


### PR DESCRIPTION
Arguments can be grouped. Groups have a Header and optional a description. Every argument is in the default Group "arguments", if no other group is assigned.

Fixes Issue #22 
2nd Version.

Example:

```
nitro::broken_options::parser parser("app_name", "about");

parser.group("group1").option("opt", "some opt").short_name("o");
parser.group("group2").toggle("tog", "some toggle").short_name("t");
parser.group("group2").toggle("togg", "some other toggle").short_name("u");
```
OR
```
nitro::broken_options::parser parser("app_name", "about");

auto grp1 = parser.group("group1");
auto grp2 = parser.group("group2");

grp1.option("opt", "some opt").short_name("o");
grp2.toggle("tog", "some toggle").short_name("t");
grp2.toggle("togg", "some other toggle").short_name("u");
```


Output:

```
usage: app_name --opt

about


group1:
  -o [ --opt ] arg                        some opt

group2:
  -t [ --tog ]                            some toggle
  -u [ --togg ]                           some other toggle
```
