### PR TITLE
toggle_prefixes

### DIFF
--- a/include/nitro/broken_options/argument.hpp
+++ b/include/nitro/broken_options/argument.hpp
@@ -70,7 +70,7 @@ namespace broken_options
         }
 
     public:
-        bool is_value() const noexcept 
+        bool is_value() const noexcept
         {
             return name_[0] != '-';
         }
@@ -85,7 +85,7 @@ namespace broken_options
             return name_.size() > 1 && name_[0] == '-' && name_[1] != '-';
         }
 
-        bool is_named() const  noexcept
+        bool is_named() const noexcept
         {
             return name_.size() > 2 && name_[0] == '-' && name_[1] == '-' && name_[2] != '-';
         }
@@ -102,7 +102,7 @@ namespace broken_options
 
         bool has_prefix() const
         {
-            return nitro::lang::starts_with(name_,"--no-");
+            return nitro::lang::starts_with(name_, "--no-");
         }
 
     public:
@@ -115,7 +115,8 @@ namespace broken_options
         {
             if (!has_prefix())
             {
-                raise<parser_error>("Trying to get the name without prefix but prefix is not given.");
+                raise<parser_error>(
+                    "Trying to get the name without prefix but prefix is not given.");
             }
             return name().substr(5);
         }

--- a/include/nitro/broken_options/argument.hpp
+++ b/include/nitro/broken_options/argument.hpp
@@ -113,6 +113,10 @@ namespace broken_options
 
         std::string name_without_prefix() const
         {
+            if (!has_prefix())
+            {
+                raise<parser_error>("Trying to get the name without prefix but prefix is not given.");
+            }
             std::string tmp = name();
             return tmp.erase(0,5);
         }

--- a/include/nitro/broken_options/argument.hpp
+++ b/include/nitro/broken_options/argument.hpp
@@ -34,6 +34,7 @@
 
 #include <nitro/except/raise.hpp>
 #include <nitro/lang/optional.hpp>
+#include <nitro/lang/string.hpp>
 
 #include <regex>
 #include <set>
@@ -99,6 +100,11 @@ namespace broken_options
             return is_value() || static_cast<bool>(value_);
         }
 
+        bool has_prefix() const
+        {
+            return nitro::lang::starts_with(name_,"--no-");
+        }
+
     public:
         const std::string& data() const noexcept
         {
@@ -113,6 +119,11 @@ namespace broken_options
             }
 
             return name_;
+        }
+
+        std::string name_without_prefix() const
+        {
+            return 
         }
 
         const std::string& value() const

--- a/include/nitro/broken_options/argument.hpp
+++ b/include/nitro/broken_options/argument.hpp
@@ -117,8 +117,7 @@ namespace broken_options
             {
                 raise<parser_error>("Trying to get the name without prefix but prefix is not given.");
             }
-            std::string tmp = name();
-            return tmp.erase(0,5);
+            return name().substr(5);
         }
 
         const std::string& name() const

--- a/include/nitro/broken_options/argument.hpp
+++ b/include/nitro/broken_options/argument.hpp
@@ -70,7 +70,7 @@ namespace broken_options
         }
 
     public:
-        bool is_value() const noexcept
+        bool is_value() const noexcept 
         {
             return name_[0] != '-';
         }
@@ -85,7 +85,7 @@ namespace broken_options
             return name_.size() > 1 && name_[0] == '-' && name_[1] != '-';
         }
 
-        bool is_named() const noexcept
+        bool is_named() const  noexcept
         {
             return name_.size() > 2 && name_[0] == '-' && name_[1] == '-' && name_[2] != '-';
         }
@@ -111,6 +111,12 @@ namespace broken_options
             return arg_;
         }
 
+        std::string name_without_prefix() const
+        {
+            std::string tmp = name();
+            return tmp.erase(0,5);
+        }
+
         const std::string& name() const
         {
             if (is_value())
@@ -119,11 +125,6 @@ namespace broken_options
             }
 
             return name_;
-        }
-
-        std::string name_without_prefix() const
-        {
-            return 
         }
 
         const std::string& value() const

--- a/include/nitro/broken_options/option/base.hpp
+++ b/include/nitro/broken_options/option/base.hpp
@@ -143,11 +143,6 @@ namespace broken_options
             return s << std::endl;
         }
 
-    private:
-        virtual void update_value(const argument& data) = 0;
-        virtual void prepare() = 0;
-        virtual void check() = 0;
-
         virtual bool matches(const argument& arg)
         {
             if (!arg.is_argument())
@@ -173,6 +168,11 @@ namespace broken_options
 
             return false;
         }
+
+    private:
+        virtual void update_value(const argument& data) = 0;
+        virtual void prepare() = 0;
+        virtual void check() = 0;
 
         friend class parser;
 

--- a/include/nitro/broken_options/option/toggle.hpp
+++ b/include/nitro/broken_options/option/toggle.hpp
@@ -160,24 +160,7 @@ namespace broken_options
 
         bool matches(const argument& arg) override
         {
-            if (!arg.is_argument())
-            {
-                return false;
-            }
-
-            if (has_short_name() && arg.is_short())
-            {
-                auto list = arg.as_short_list();
-
-                if (list.size() > 1 && arg.has_value())
-                {
-                    return false;
-                }
-
-                return list.count(short_name());
-            }
-
-            else if (arg.is_named())
+            if (arg.is_named())
             {
                 if (arg.has_prefix())
                 {
@@ -189,7 +172,7 @@ namespace broken_options
                 }
             }
 
-            return false;
+            return base::matches(arg);
         }
 
         friend class parser;

--- a/include/nitro/broken_options/option/toggle.hpp
+++ b/include/nitro/broken_options/option/toggle.hpp
@@ -104,15 +104,47 @@ namespace broken_options
                     // FeelsBadMan
                     if (env_value == "TRUE" || env_value == "ON" || env_value == "YES" ||
                         env_value == "true" || env_value == "on" || env_value == "yes" ||
-                        env_value == "1" || env_value == "Y")
+                        env_value == "1" || env_value == "Y" || env_value == "with")
                     {
                         update_value({ "--" + name() });
+                    }
+                    if (env_value == "false" || env_value == "FALSE" ||env_value == "without" ||
+                        env_value == "0" || env_value == "NO" || env_value == "no" ||
+                        env_value == "without" || env_value == "n" || env_value == "off" ||
+                        env_value == "OFF")
+                    {
+                        update_value({ "--" + name()});
                     }
                     return;
                 }
             }
         }
+        bool matches(const argument& arg) override
+        {
+            if (!arg.is_argument())
+            {
+                return false;
+            }
 
+            if (has_short_name() && arg.is_short())
+            {
+                auto list = arg.as_short_list();
+
+                if (list.size() > 1 && arg.has_value())
+                {
+                    return false;
+                }
+
+                return list.count(short_name());
+            }
+            else if (arg.is_named())
+            {
+                return arg.as_named() == name();
+            }
+            
+            return false;
+        }
+        
         friend class parser;
 
     private:

--- a/include/nitro/broken_options/option/toggle.hpp
+++ b/include/nitro/broken_options/option/toggle.hpp
@@ -66,9 +66,32 @@ namespace broken_options
             return given_;
         }
 
+
+
     public:
         virtual void format_value(std::ostream&) const override
         {
+        }
+
+        static bool parse_env_value(const std::string& env_value)
+        {
+            if (env_value == "TRUE" || env_value == "ON" || env_value == "YES" ||
+                env_value == "true" || env_value == "on" || env_value == "yes" ||
+                env_value == "1" || env_value == "Y" || env_value == "with" ||
+                env_value == "True" || env_value == "On" || env_value == "WITH" ||
+                env_value == "With" || env_value == "y" || env_value == "Yes")
+            {
+                return true;
+            }
+            if (env_value == "false" || env_value == "FALSE" ||env_value == "without" ||
+                env_value == "0" || env_value == "NO" || env_value == "no" ||
+                env_value == "Without" || env_value == "n" || env_value == "off" ||
+                env_value == "OFF" || env_value == "N" || env_value == "False" ||
+                env_value == "Off" || env_value == "WITHOUT" || env_value == "No")
+            {
+                return false;
+            }
+            raise<parsing_error>("Can't parse env variable");
         }
 
     private:
@@ -99,6 +122,8 @@ namespace broken_options
         {
         }
 
+        
+
         virtual void check() override
         {
             if (has_env() && !given())
@@ -110,18 +135,13 @@ namespace broken_options
                     // Python code would look like this:
                     // if bool(env_value):
                     // FeelsBadMan
-                    if (env_value == "TRUE" || env_value == "ON" || env_value == "YES" ||
-                        env_value == "true" || env_value == "on" || env_value == "yes" ||
-                        env_value == "1" || env_value == "Y" || env_value == "with")
+                    if (parse_env_value(env_value))
                     {
                         update_value({ "--" + name() });
                     }
-                    if (env_value == "false" || env_value == "FALSE" ||env_value == "without" ||
-                        env_value == "0" || env_value == "NO" || env_value == "no" ||
-                        env_value == "without" || env_value == "n" || env_value == "off" ||
-                        env_value == "OFF")
+                    else
                     {
-                        update_value({ "--" + name()});
+                        update_value({ "--no-" + name()});
                     }
                     return;
                 }
@@ -147,9 +167,16 @@ namespace broken_options
             }
             else if (arg.is_named())
             {
-                return arg.as_named() == name();
+                if (arg.has_prefix())
+                {
+                    return arg.name_without_prefix() == name();
+                }
+                else
+                {
+                    return arg.as_named() == name();
+                }
             }
-            
+
             return false;
         }
         

--- a/include/nitro/broken_options/option/toggle.hpp
+++ b/include/nitro/broken_options/option/toggle.hpp
@@ -121,6 +121,7 @@ namespace broken_options
             {
                 given_ = 0;
             }
+
             else
             {
                 ++given_;
@@ -146,14 +147,17 @@ namespace broken_options
                     {
                         update_value({ "--" + name() });
                     }
+
                     else
                     {
                         update_value({ "--no-" + name()});
                     }
+
                     return;
                 }
             }
         }
+
         bool matches(const argument& arg) override
         {
             if (!arg.is_argument())
@@ -172,6 +176,7 @@ namespace broken_options
 
                 return list.count(short_name());
             }
+
             else if (arg.is_named())
             {
                 if (arg.has_prefix())
@@ -186,7 +191,7 @@ namespace broken_options
 
             return false;
         }
-        
+
         friend class parser;
 
     private:

--- a/include/nitro/broken_options/option/toggle.hpp
+++ b/include/nitro/broken_options/option/toggle.hpp
@@ -84,7 +84,15 @@ namespace broken_options
                 *ref_ = true;
             }
 
-            ++given_;
+            if (arg.has_prefix())
+            {
+                given_ = 0;
+            }
+            else
+            {
+                ++given_;
+            }
+            //++given_;
         }
 
         virtual void prepare() override

--- a/include/nitro/broken_options/option/toggle.hpp
+++ b/include/nitro/broken_options/option/toggle.hpp
@@ -66,7 +66,17 @@ namespace broken_options
             return given_;
         }
 
-
+        int default_value(const bool& def)
+        {
+            if(def)
+            {
+                return given_ = 1;
+            }
+            else
+            {
+                return given_ = 0;
+            }
+        }
 
     public:
         virtual void format_value(std::ostream&) const override
@@ -121,8 +131,6 @@ namespace broken_options
         virtual void prepare() override
         {
         }
-
-        
 
         virtual void check() override
         {

--- a/include/nitro/broken_options/option/toggle.hpp
+++ b/include/nitro/broken_options/option/toggle.hpp
@@ -68,7 +68,7 @@ namespace broken_options
 
         int default_value(bool def)
         {
-            if(def)
+            if (def)
             {
                 return given_ = 1;
             }
@@ -93,7 +93,7 @@ namespace broken_options
             {
                 return true;
             }
-            if (env_value == "false" || env_value == "FALSE" ||env_value == "without" ||
+            if (env_value == "false" || env_value == "FALSE" || env_value == "without" ||
                 env_value == "0" || env_value == "NO" || env_value == "no" ||
                 env_value == "Without" || env_value == "n" || env_value == "off" ||
                 env_value == "OFF" || env_value == "N" || env_value == "False" ||
@@ -150,7 +150,7 @@ namespace broken_options
 
                     else
                     {
-                        update_value({ "--no-" + name()});
+                        update_value({ "--no-" + name() });
                     }
 
                     return;

--- a/include/nitro/broken_options/option/toggle.hpp
+++ b/include/nitro/broken_options/option/toggle.hpp
@@ -66,7 +66,7 @@ namespace broken_options
             return given_;
         }
 
-        int default_value(const bool& def)
+        int default_value(bool def)
         {
             if(def)
             {
@@ -125,7 +125,6 @@ namespace broken_options
             {
                 ++given_;
             }
-            //++given_;
         }
 
         virtual void prepare() override

--- a/include/nitro/broken_options/parser.ipp
+++ b/include/nitro/broken_options/parser.ipp
@@ -317,7 +317,7 @@ namespace broken_options
 
         for (auto& option : toggles_)
         {
-            if (option.second.matches(it->name()))
+            if (option.second.matches(*it))
             {
                 option.second.update_value(*it);
                 match_found = true;

--- a/tests/broken_options_test.cpp
+++ b/tests/broken_options_test.cpp
@@ -990,7 +990,7 @@ TEST_CASE("toggle with prefix ")
         REQUIRE(!options.given("arg"));
     }
 
-    SECTION("test default_value8) function with positiv value")
+    SECTION("test default_value() function with positiv value")
     {
         int argc = 1;
         const char* argv[] = { "" };
@@ -1004,7 +1004,7 @@ TEST_CASE("toggle with prefix ")
         REQUIRE(options.given("arg"));
     }
 
-    SECTION("test default_value8) function with negativ value")
+    SECTION("test default_value()) function with negativ value")
     {
         int argc = 1;
         const char* argv[] = { "" };

--- a/tests/broken_options_test.cpp
+++ b/tests/broken_options_test.cpp
@@ -960,9 +960,9 @@ TEST_CASE("Reading the value from the ENV variables", "[broken_options]")
     }
 }
 
-TEST_CASE("toggle with prefix ")
+TEST_CASE("parsing toggles with prefix and default value")
 {
-    SECTION("--no- test")
+    SECTION("test argument with --no- is parsed right")
     {
         nitro::broken_options::argument arg("--no-arg");
         REQUIRE(arg.has_prefix());

--- a/tests/broken_options_test.cpp
+++ b/tests/broken_options_test.cpp
@@ -966,7 +966,7 @@ TEST_CASE("parsing toggles with prefix and default value")
     {
         nitro::broken_options::argument arg("--no-arg");
         REQUIRE(arg.has_prefix());
-        REQUIRE(arg.name_without_prefix()== "arg") ;
+        REQUIRE(arg.name_without_prefix() == "arg");
     }
 
     SECTION("argument without prefix work")
@@ -1077,7 +1077,8 @@ TEST_CASE("parsing toggles with prefix and default value")
         using namespace nitro::broken_options;
 
         REQUIRE_THROWS_AS(toggle::parse_env_value("fddgh"), nitro::broken_options::parsing_error);
-        REQUIRE_THROWS_AS(toggle::parse_env_value("fdd-gdegh"), nitro::broken_options::parsing_error);
+        REQUIRE_THROWS_AS(toggle::parse_env_value("fdd-gdegh"),
+                          nitro::broken_options::parsing_error);
     }
 
     SECTION("arguments with prefix get properly parsed")
@@ -1094,4 +1095,3 @@ TEST_CASE("parsing toggles with prefix and default value")
         REQUIRE(named_arg.data() == "--no-ab=5");
     }
 }
-

--- a/tests/broken_options_test.cpp
+++ b/tests/broken_options_test.cpp
@@ -976,7 +976,7 @@ TEST_CASE("parsing toggles with prefix and default value")
         REQUIRE_THROWS_AS(arg.name_without_prefix(), nitro::broken_options::parser_error);
     }
 
-    SECTION("test check() function")
+    SECTION("parsing an argument with prefix and testing check() function")
     {
         int argc = 2;
         const char* argv[] = { "", "--no-arg" };

--- a/tests/broken_options_test.cpp
+++ b/tests/broken_options_test.cpp
@@ -959,3 +959,125 @@ TEST_CASE("Reading the value from the ENV variables", "[broken_options]")
         CHECK(options.get("opt4", 0) == "foo");
     }
 }
+
+TEST_CASE("toggle with prefix ")
+{
+    SECTION("--no- test")
+    {
+        nitro::broken_options::argument arg("--no-arg");
+        REQUIRE(arg.has_prefix());
+        REQUIRE(arg.name_without_prefix()== "arg") ;
+    }
+
+    SECTION("argument without prefix work")
+    {
+        nitro::broken_options::argument arg("--arg");
+        REQUIRE(!arg.has_prefix());
+        REQUIRE_THROWS_AS(arg.name_without_prefix(), nitro::broken_options::parser_error);
+    }
+
+    SECTION("test check() function")
+    {
+        int argc = 2;
+        const char* argv[] = { "", "--no-arg" };
+
+        nitro::broken_options::parser parser;
+
+        parser.toggle("arg");
+
+        auto options = parser.parse(argc, argv);
+
+        REQUIRE(!options.given("arg"));
+    }
+
+    SECTION("test check() function")
+    {
+        int argc = 1;
+        const char* argv[] = { "" };
+
+        nitro::broken_options::parser parser;
+
+        parser.toggle("arg").default(true);
+
+        auto options = parser.parse(argc, argv);
+
+        REQUIRE(options.given("arg"));
+    }
+
+    SECTION("test negativ env_var")
+    {
+        int argc = 1;
+        const char* argv[] = { "" };
+
+        nitro::broken_options::parser parser;
+
+        parser.toggle("arg").env("OPT3");
+
+        auto options = parser.parse(argc, argv);
+
+        REQUIRE(!options.given("arg"));
+    }
+
+    SECTION("test parse_env_value() function with positiv env_value")
+    {
+        using namespace nitro::broken_options;
+
+        REQUIRE(toggle::parse_env_value("TRUE"));
+        REQUIRE(toggle::parse_env_value("True"));
+        REQUIRE(toggle::parse_env_value("true"));
+        REQUIRE(toggle::parse_env_value("1"));
+        REQUIRE(toggle::parse_env_value("ON"));
+        REQUIRE(toggle::parse_env_value("On"));
+        REQUIRE(toggle::parse_env_value("on"));
+        REQUIRE(toggle::parse_env_value("WITH"));
+        REQUIRE(toggle::parse_env_value("with"));
+        REQUIRE(toggle::parse_env_value("y"));
+        REQUIRE(toggle::parse_env_value("Y"));
+        REQUIRE(toggle::parse_env_value("YES"));
+        REQUIRE(toggle::parse_env_value("Yes"));
+        REQUIRE(toggle::parse_env_value("yes"));
+    }
+
+    SECTION("test parse_env_value() function with negativ env_value")
+    {
+        using namespace nitro::broken_options;
+
+        REQUIRE(!toggle::parse_env_value("False"));
+        REQUIRE(!toggle::parse_env_value("FALSE"));
+        REQUIRE(!toggle::parse_env_value("false"));
+        REQUIRE(!toggle::parse_env_value("OFF"));
+        REQUIRE(!toggle::parse_env_value("Off"));
+        REQUIRE(!toggle::parse_env_value("off"));
+        REQUIRE(!toggle::parse_env_value("0"));
+        REQUIRE(!toggle::parse_env_value("without"));
+        REQUIRE(!toggle::parse_env_value("WITHOUT"));
+        REQUIRE(!toggle::parse_env_value("NO"));
+        REQUIRE(!toggle::parse_env_value("No"));
+        REQUIRE(!toggle::parse_env_value("no"));
+        REQUIRE(!toggle::parse_env_value("N"));
+        REQUIRE(!toggle::parse_env_value("n"));
+    }
+
+    SECTION("test parse_env_value() function with error env_value")
+    {
+        using namespace nitro::broken_options;
+
+        REQUIRE_THROWS_AS(toggle::parse_env_value("fddgh"), nitro::broken_options::parsing_error);
+        REQUIRE_THROWS_AS(toggle::parse_env_value("fdd-gdegh"), nitro::broken_options::parsing_error);
+    }
+
+    SECTION("arguments with prefix get properly parsed")
+    {
+        nitro::broken_options::argument named_arg("--no-ab=5");
+        REQUIRE(named_arg.is_argument());
+        REQUIRE(!named_arg.is_short());
+        REQUIRE(named_arg.is_named());
+        REQUIRE(named_arg.has_value());
+        REQUIRE(named_arg.has_prefix());
+        REQUIRE(named_arg.value() == "5");
+        REQUIRE(named_arg.name() == "--no-ab");
+        REQUIRE(named_arg.name_without_prefix() == "ab");
+        REQUIRE(named_arg.data() == "--no-ab=5");
+    }
+}
+

--- a/tests/broken_options_test.cpp
+++ b/tests/broken_options_test.cpp
@@ -990,18 +990,32 @@ TEST_CASE("toggle with prefix ")
         REQUIRE(!options.given("arg"));
     }
 
-    SECTION("test check() function")
+    SECTION("test default_value8) function with positiv value")
     {
         int argc = 1;
         const char* argv[] = { "" };
 
         nitro::broken_options::parser parser;
 
-        parser.toggle("arg").default(true);
+        parser.toggle("arg").default_value(true);
 
         auto options = parser.parse(argc, argv);
 
         REQUIRE(options.given("arg"));
+    }
+
+    SECTION("test default_value8) function with negativ value")
+    {
+        int argc = 1;
+        const char* argv[] = { "" };
+
+        nitro::broken_options::parser parser;
+
+        parser.toggle("arg").default_value(false);
+
+        auto options = parser.parse(argc, argv);
+
+        REQUIRE(!options.given("arg"));
     }
 
     SECTION("test negativ env_var")


### PR DESCRIPTION
Parser understand --no- as a prefix to invert the boolean value and the default value is changeable.
Add new functions:
- parse_env_value() : parse env_value return boolean value
- has_prefix(): test if arg has a prefix
- name_without_prefix(): return name without prefix(--no-)
- default_value(): set given_ value to 1 or 0

Add a lot of test for new functions