### PR TITLE
Set prefix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,5 @@
 
 build
 .clang_complete
+cmake_build_debug
+Testing

--- a/include/nitro/broken_options/argument.hpp
+++ b/include/nitro/broken_options/argument.hpp
@@ -49,6 +49,9 @@ namespace broken_options
     public:
         argument(const std::string& arg) : arg_(arg)
         {
+            std::regex rex;
+            rex = "^--([a-zA-Z]*)-.*";
+            std::smatch matches;
             auto sep = arg_.find("=");
             if (sep != std::string::npos)
             {
@@ -59,6 +62,10 @@ namespace broken_options
             {
                 name_ = arg_;
             }
+            if (std::regex_search(name_, matches, rex))
+                {
+                    prefix_ =  matches[1];
+                }
 
             if (!is_value() && !is_double_dash())
             {
@@ -102,13 +109,18 @@ namespace broken_options
 
         bool has_prefix() const
         {
-            return nitro::lang::starts_with(name_, "--no-");
+            return !prefix_.empty();
         }
 
     public:
         const std::string& data() const noexcept
         {
             return arg_;
+        }
+
+        const std::string& prefix() const
+        {
+            return prefix_;
         }
 
         std::string name_without_prefix() const
@@ -118,7 +130,8 @@ namespace broken_options
                 raise<parser_error>(
                     "Trying to get the name without prefix but prefix is not given.");
             }
-            return name().substr(5);
+            int end = 2 + prefix_.length() + 1;
+            return name().substr(end);
         }
 
         const std::string& name() const
@@ -178,6 +191,7 @@ namespace broken_options
     private:
         std::string arg_;
         std::string name_;
+        std::string prefix_;
         lang::optional<std::string> value_;
     };
 } // namespace broken_options

--- a/include/nitro/broken_options/argument.hpp
+++ b/include/nitro/broken_options/argument.hpp
@@ -1,18 +1,18 @@
 **Copyright(c) 2015 - 2016, Technische Universität Dresden,
-    Germany* All rights reserved.** Redistribution and use in source and binary forms,
+    Germany* All rights reserved.**Redistribution and use in source and binary forms,
     with or without modification,
     are permitted* provided that the following conditions are met
 : **1. Redistributions of source code must retain the above copyright notice,
-  this list of conditions*and the following disclaimer.* *
-      2. Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions*and the following disclaimer.*
+      *2. Redistributions in binary form must reproduce the above copyright notice,
   this list of* conditions and the following disclaimer in the documentation and / or
-      other materials provided* with the distribution.* *
-          3. Neither the name of the copyright holder nor the names of its
+      other materials provided* with the distribution.*
+          *3. Neither the name of the copyright holder nor the names of its
           contributors may be used to* endorse
       or
-      promote products derived from this software without specific prior written* permission
-          .** THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-      "AS IS" AND ANY EXPRESS OR* IMPLIED WARRANTIES,
+      promote products derived from this software without specific prior written* permission.*
+          *THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+          "AS IS" AND ANY EXPRESS OR* IMPLIED WARRANTIES,
   INCLUDING,
   BUT NOT LIMITED TO,
   THE IMPLIED WARRANTIES OF MERCHANTABILITY AND* FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -28,7 +28,7 @@
   *WHETHER IN CONTRACT,
   STRICT LIABILITY,
   OR TORT(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY* WAY OUT OF THE USE OF THIS SOFTWARE,
-  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.* /
+  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.*/
 
 #ifndef INCLUDE_NITRO_BROKEN_OPTIONS_ARGUMENT_HPP
 #define INCLUDE_NITRO_BROKEN_OPTIONS_ARGUMENT_HPP

--- a/include/nitro/broken_options/argument.hpp
+++ b/include/nitro/broken_options/argument.hpp
@@ -1,4 +1,4 @@
-/*
+*
  * Copyright (c) 2015-2016, Technische Universität Dresden, Germany
  * All rights reserved.
  *
@@ -63,9 +63,9 @@ namespace broken_options
                 name_ = arg_;
             }
             if (std::regex_search(name_, matches, rex))
-                {
-                    prefix_ =  matches[1];
-                }
+            {
+                prefix_ = matches[1];
+            }
 
             if (!is_value() && !is_double_dash())
             {

--- a/include/nitro/broken_options/argument.hpp
+++ b/include/nitro/broken_options/argument.hpp
@@ -1,30 +1,34 @@
-*
- * Copyright (c) 2015-2016, Technische Universität Dresden, Germany
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without modification, are permitted
- * provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice, this list of conditions
- *    and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice, this list of
- *    conditions and the following disclaimer in the documentation and/or other materials provided
- *    with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors may be used to
- *    endorse or promote products derived from this software without specific prior written
- *    permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
- * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
- * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
- * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
- * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
- * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
- * WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+**Copyright(c) 2015 - 2016, Technische Universität Dresden,
+    Germany* All rights reserved.** Redistribution and use in source and binary forms,
+    with or without modification,
+    are permitted* provided that the following conditions are met
+: **1. Redistributions of source code must retain the above copyright notice,
+  this list of conditions*and the following disclaimer.* *
+      2. Redistributions in binary form must reproduce the above copyright notice,
+  this list of* conditions and the following disclaimer in the documentation and / or
+      other materials provided* with the distribution.* *
+          3. Neither the name of the copyright holder nor the names of its
+          contributors may be used to* endorse
+      or
+      promote products derived from this software without specific prior written* permission
+          .** THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+      "AS IS" AND ANY EXPRESS OR* IMPLIED WARRANTIES,
+  INCLUDING,
+  BUT NOT LIMITED TO,
+  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND* FITNESS FOR A PARTICULAR PURPOSE ARE
+  DISCLAIMED.IN NO EVENT SHALL THE COPYRIGHT HOLDER OR* CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+  INDIRECT,
+  INCIDENTAL,
+  SPECIAL,
+  EXEMPLARY,
+  OR CONSEQUENTIAL* DAMAGES(INCLUDING, BUT NOT LIMITED TO,
+                            PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+                            LOSS OF USE, *DATA, OR PROFITS;
+                            OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+  *WHETHER IN CONTRACT,
+  STRICT LIABILITY,
+  OR TORT(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY* WAY OUT OF THE USE OF THIS SOFTWARE,
+  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.* /
 
 #ifndef INCLUDE_NITRO_BROKEN_OPTIONS_ARGUMENT_HPP
 #define INCLUDE_NITRO_BROKEN_OPTIONS_ARGUMENT_HPP
@@ -40,161 +44,162 @@
 #include <set>
 #include <string>
 
-namespace nitro
+      namespace nitro
 {
-namespace broken_options
-{
-    class argument
+    namespace broken_options
     {
-    public:
-        argument(const std::string& arg) : arg_(arg)
+        class argument
         {
-            std::regex rex;
-            rex = "^--([a-zA-Z]*)-.*";
-            std::smatch matches;
-            auto sep = arg_.find("=");
-            if (sep != std::string::npos)
+        public:
+            argument(const std::string& arg) : arg_(arg)
             {
-                name_ = arg_.substr(0, sep);
-                value_ = arg_.substr(sep + 1);
-            }
-            else
-            {
-                name_ = arg_;
-            }
-            if (std::regex_search(name_, matches, rex))
-            {
-                prefix_ = matches[1];
-            }
-
-            if (!is_value() && !is_double_dash())
-            {
-                if (!std::regex_match(arg, std::regex("-{1,2}[^-=]+[^=]*=?.*")))
+                std::regex rex;
+                rex = "^--([a-zA-Z]*)-.*";
+                std::smatch matches;
+                auto sep = arg_.find("=");
+                if (sep != std::string::npos)
                 {
-                    raise<parsing_error>("The argument couldn't be parsed.");
+                    name_ = arg_.substr(0, sep);
+                    value_ = arg_.substr(sep + 1);
+                }
+                else
+                {
+                    name_ = arg_;
+                }
+                if (std::regex_search(name_, matches, rex))
+                {
+                    prefix_ = matches[1];
+                }
+
+                if (!is_value() && !is_double_dash())
+                {
+                    if (!std::regex_match(arg, std::regex("-{1,2}[^-=]+[^=]*=?.*")))
+                    {
+                        raise<parsing_error>("The argument couldn't be parsed.");
+                    }
                 }
             }
-        }
 
-    public:
-        bool is_value() const noexcept
-        {
-            return name_[0] != '-';
-        }
-
-        bool is_double_dash() const noexcept
-        {
-            return arg_ == "--";
-        }
-
-        bool is_short() const noexcept
-        {
-            return name_.size() > 1 && name_[0] == '-' && name_[1] != '-';
-        }
-
-        bool is_named() const noexcept
-        {
-            return name_.size() > 2 && name_[0] == '-' && name_[1] == '-' && name_[2] != '-';
-        }
-
-        bool is_argument() const noexcept
-        {
-            return is_short() || is_named();
-        }
-
-        bool has_value() const noexcept
-        {
-            return is_value() || static_cast<bool>(value_);
-        }
-
-        bool has_prefix() const
-        {
-            return !prefix_.empty();
-        }
-
-    public:
-        const std::string& data() const noexcept
-        {
-            return arg_;
-        }
-
-        const std::string& prefix() const
-        {
-            return prefix_;
-        }
-
-        std::string name_without_prefix() const
-        {
-            if (!has_prefix())
+        public:
+            bool is_value() const noexcept
             {
-                raise<parser_error>(
-                    "Trying to get the name without prefix but prefix is not given.");
-            }
-            int end = 2 + prefix_.length() + 1;
-            return name().substr(end);
-        }
-
-        const std::string& name() const
-        {
-            if (is_value())
-            {
-                raise<parser_error>("Trying to get the name of a pure value argument.");
+                return name_[0] != '-';
             }
 
-            return name_;
-        }
-
-        const std::string& value() const
-        {
-            if (!has_value())
+            bool is_double_dash() const noexcept
             {
-                raise<parser_error>(
-                    "Trying to read the value of an argument that does not have a value.");
+                return arg_ == "--";
             }
 
-            if (is_value())
+            bool is_short() const noexcept
+            {
+                return name_.size() > 1 && name_[0] == '-' && name_[1] != '-';
+            }
+
+            bool is_named() const noexcept
+            {
+                return name_.size() > 2 && name_[0] == '-' && name_[1] == '-' && name_[2] != '-';
+            }
+
+            bool is_argument() const noexcept
+            {
+                return is_short() || is_named();
+            }
+
+            bool has_value() const noexcept
+            {
+                return is_value() || static_cast<bool>(value_);
+            }
+
+            bool has_prefix() const
+            {
+                return !prefix_.empty();
+            }
+
+        public:
+            const std::string& data() const noexcept
             {
                 return arg_;
             }
 
-            return *value_;
-        }
-
-        std::multiset<std::string> as_short_list() const
-        {
-            if (!is_short())
+            const std::string& prefix() const
             {
-                raise<parser_error>(
-                    "Trying to interpret argument as short options list, but it ain't.");
+                return prefix_;
             }
 
-            std::multiset<std::string> result;
-
-            for (std::size_t i = 1; i < name_.size(); i++)
+            std::string name_without_prefix() const
             {
-                result.emplace(1, arg_[i]);
+                if (!has_prefix())
+                {
+                    raise<parser_error>(
+                        "Trying to get the name without prefix but prefix is not given.");
+                }
+                int end = 2 + prefix_.length() + 1;
+                return name().substr(end);
             }
 
-            return result;
-        }
-
-        std::string as_named() const
-        {
-            if (!is_named())
+            const std::string& name() const
             {
-                raise<parser_error>("Trying to interpret argument as named option, but it ain't.");
+                if (is_value())
+                {
+                    raise<parser_error>("Trying to get the name of a pure value argument.");
+                }
+
+                return name_;
             }
 
-            return { name_.begin() + 2, name_.end() };
-        }
+            const std::string& value() const
+            {
+                if (!has_value())
+                {
+                    raise<parser_error>(
+                        "Trying to read the value of an argument that does not have a value.");
+                }
 
-    private:
-        std::string arg_;
-        std::string name_;
-        std::string prefix_;
-        lang::optional<std::string> value_;
-    };
-} // namespace broken_options
+                if (is_value())
+                {
+                    return arg_;
+                }
+
+                return *value_;
+            }
+
+            std::multiset<std::string> as_short_list() const
+            {
+                if (!is_short())
+                {
+                    raise<parser_error>(
+                        "Trying to interpret argument as short options list, but it ain't.");
+                }
+
+                std::multiset<std::string> result;
+
+                for (std::size_t i = 1; i < name_.size(); i++)
+                {
+                    result.emplace(1, arg_[i]);
+                }
+
+                return result;
+            }
+
+            std::string as_named() const
+            {
+                if (!is_named())
+                {
+                    raise<parser_error>(
+                        "Trying to interpret argument as named option, but it ain't.");
+                }
+
+                return { name_.begin() + 2, name_.end() };
+            }
+
+        private:
+            std::string arg_;
+            std::string name_;
+            std::string prefix_;
+            lang::optional<std::string> value_;
+        };
+    } // namespace broken_options
 } // namespace nitro
 
 #endif // INCLUDE_NITRO_BROKEN_OPTIONS_ARGUMENT_HPP

--- a/include/nitro/broken_options/option/base.hpp
+++ b/include/nitro/broken_options/option/base.hpp
@@ -76,6 +76,7 @@ namespace broken_options
         {
             return *env_;
         }
+
         const std::string& arg_name() const
         {
             return arg_name_;
@@ -210,6 +211,7 @@ namespace broken_options
 
             return *static_cast<Option*>(this);
         }
+
         Option& short_name(const std::string& short_name)
         {
             if (short_ && *short_ != short_name)

--- a/include/nitro/broken_options/option/base.hpp
+++ b/include/nitro/broken_options/option/base.hpp
@@ -76,6 +76,10 @@ namespace broken_options
         {
             return *env_;
         }
+        const std::string& arg_name() const
+        {
+            return arg_name_;
+        }
 
         virtual void format_value(std::ostream& s) const = 0;
 
@@ -183,6 +187,7 @@ namespace broken_options
     protected:
         nitro::lang::optional<std::string> short_;
         nitro::lang::optional<std::string> env_;
+        std::string arg_name_ = "arg";
     };
 
     template <typename Option>
@@ -192,7 +197,19 @@ namespace broken_options
         using base::base;
         using base::env;
         using base::short_name;
+        using base::arg_name;
 
+        Option& arg_name(const std::string& metavar)
+        {
+            if (metavar.empty())
+            {
+                raise<parser_error>("Trying to assign empty string to argument name");
+            }
+
+            arg_name_ = metavar;
+
+            return *static_cast<Option*>(this);
+        }
         Option& short_name(const std::string& short_name)
         {
             if (short_ && *short_ != short_name)

--- a/include/nitro/broken_options/option/base.hpp
+++ b/include/nitro/broken_options/option/base.hpp
@@ -204,7 +204,7 @@ namespace broken_options
         {
             if (arg_name.empty())
             {
-                raise<parser_error>("Trying to assign empty string to argument name");
+                raise<parser_error>("Trying to assign empty string to metavar");
             }
 
             arg_name_ = arg_name;

--- a/include/nitro/broken_options/option/base.hpp
+++ b/include/nitro/broken_options/option/base.hpp
@@ -197,8 +197,8 @@ namespace broken_options
     public:
         using base::base;
         using base::env;
-        using base::short_name;
         using base::metavar;
+        using base::short_name;
 
         Option& metavar(const std::string& arg_name)
         {

--- a/include/nitro/broken_options/option/base.hpp
+++ b/include/nitro/broken_options/option/base.hpp
@@ -77,7 +77,7 @@ namespace broken_options
             return *env_;
         }
 
-        const std::string& arg_name() const
+        const std::string& metavar() const
         {
             return arg_name_;
         }
@@ -198,16 +198,16 @@ namespace broken_options
         using base::base;
         using base::env;
         using base::short_name;
-        using base::arg_name;
+        using base::metavar;
 
-        Option& arg_name(const std::string& metavar)
+        Option& metavar(const std::string& arg_name)
         {
-            if (metavar.empty())
+            if (arg_name.empty())
             {
                 raise<parser_error>("Trying to assign empty string to argument name");
             }
 
-            arg_name_ = metavar;
+            arg_name_ = arg_name;
 
             return *static_cast<Option*>(this);
         }

--- a/include/nitro/broken_options/option/multi_option.hpp
+++ b/include/nitro/broken_options/option/multi_option.hpp
@@ -102,7 +102,7 @@ namespace broken_options
             }
             else
             {
-                s << " " << arg_name();
+                s << " " << metavar();
             }
         }
 

--- a/include/nitro/broken_options/option/multi_option.hpp
+++ b/include/nitro/broken_options/option/multi_option.hpp
@@ -102,7 +102,7 @@ namespace broken_options
             }
             else
             {
-                s << " arg";
+                s << " " << arg_name();
             }
         }
 

--- a/include/nitro/broken_options/option/option.hpp
+++ b/include/nitro/broken_options/option/option.hpp
@@ -84,7 +84,7 @@ namespace broken_options
             }
             else
             {
-                s << " arg";
+                s << " " << arg_name();
             }
         }
 

--- a/include/nitro/broken_options/option/option.hpp
+++ b/include/nitro/broken_options/option/option.hpp
@@ -84,7 +84,7 @@ namespace broken_options
             }
             else
             {
-                s << " " << arg_name();
+                s << " " << metavar();
             }
         }
 

--- a/include/nitro/broken_options/option/toggle.hpp
+++ b/include/nitro/broken_options/option/toggle.hpp
@@ -125,7 +125,8 @@ namespace broken_options
                 arg.prefix() == "True" || arg.prefix() == "On" || arg.prefix() == "WITH" ||
                 arg.prefix() == "With" || arg.prefix() == "y" || arg.prefix() == "Yes")
                 {
-                    given_ = 1;
+                    given_ = 1
+                    ;
                 }
                 if (arg.prefix() == "false" || arg.prefix() == "FALSE" || arg.prefix() == "without" ||
                     arg.prefix() == "0" || arg.prefix() == "NO" || arg.prefix() == "no" ||

--- a/include/nitro/broken_options/option/toggle.hpp
+++ b/include/nitro/broken_options/option/toggle.hpp
@@ -120,19 +120,19 @@ namespace broken_options
             if (arg.has_prefix())
             {
                 if (arg.prefix() == "TRUE" || arg.prefix() == "ON" || arg.prefix() == "YES" ||
-                arg.prefix() == "true" || arg.prefix() == "on" || arg.prefix() == "yes" ||
-                arg.prefix() == "1" || arg.prefix() == "Y" || arg.prefix() == "with" ||
-                arg.prefix() == "True" || arg.prefix() == "On" || arg.prefix() == "WITH" ||
-                arg.prefix() == "With" || arg.prefix() == "y" || arg.prefix() == "Yes")
+                    arg.prefix() == "true" || arg.prefix() == "on" || arg.prefix() == "yes" ||
+                    arg.prefix() == "1" || arg.prefix() == "Y" || arg.prefix() == "with" ||
+                    arg.prefix() == "True" || arg.prefix() == "On" || arg.prefix() == "WITH" ||
+                    arg.prefix() == "With" || arg.prefix() == "y" || arg.prefix() == "Yes")
                 {
-                    given_ = 1
-                    ;
+                    given_ = 1;
                 }
-                if (arg.prefix() == "false" || arg.prefix() == "FALSE" || arg.prefix() == "without" ||
-                    arg.prefix() == "0" || arg.prefix() == "NO" || arg.prefix() == "no" ||
-                    arg.prefix() == "Without" || arg.prefix() == "n" || arg.prefix() == "off" ||
-                    arg.prefix() == "OFF" || arg.prefix() == "N" || arg.prefix() == "False" ||
-                    arg.prefix() == "Off" || arg.prefix() == "WITHOUT" || arg.prefix() == "No")
+                if (arg.prefix() == "false" || arg.prefix() == "FALSE" ||
+                    arg.prefix() == "without" || arg.prefix() == "0" || arg.prefix() == "NO" ||
+                    arg.prefix() == "no" || arg.prefix() == "Without" || arg.prefix() == "n" ||
+                    arg.prefix() == "off" || arg.prefix() == "OFF" || arg.prefix() == "N" ||
+                    arg.prefix() == "False" || arg.prefix() == "Off" || arg.prefix() == "WITHOUT" ||
+                    arg.prefix() == "No")
                 {
                     given_ = 0;
                 }

--- a/include/nitro/broken_options/option/toggle.hpp
+++ b/include/nitro/broken_options/option/toggle.hpp
@@ -119,7 +119,22 @@ namespace broken_options
 
             if (arg.has_prefix())
             {
-                given_ = 0;
+                if (arg.prefix() == "TRUE" || arg.prefix() == "ON" || arg.prefix() == "YES" ||
+                arg.prefix() == "true" || arg.prefix() == "on" || arg.prefix() == "yes" ||
+                arg.prefix() == "1" || arg.prefix() == "Y" || arg.prefix() == "with" ||
+                arg.prefix() == "True" || arg.prefix() == "On" || arg.prefix() == "WITH" ||
+                arg.prefix() == "With" || arg.prefix() == "y" || arg.prefix() == "Yes")
+                {
+                    given_ = 1;
+                }
+                if (arg.prefix() == "false" || arg.prefix() == "FALSE" || arg.prefix() == "without" ||
+                    arg.prefix() == "0" || arg.prefix() == "NO" || arg.prefix() == "no" ||
+                    arg.prefix() == "Without" || arg.prefix() == "n" || arg.prefix() == "off" ||
+                    arg.prefix() == "OFF" || arg.prefix() == "N" || arg.prefix() == "False" ||
+                    arg.prefix() == "Off" || arg.prefix() == "WITHOUT" || arg.prefix() == "No")
+                {
+                    given_ = 0;
+                }
             }
 
             else

--- a/tests/broken_options_test.cpp
+++ b/tests/broken_options_test.cpp
@@ -982,4 +982,27 @@ arguments:
   --opt_nosd test                         some opt without short and default
 )EXPECTED");
     }
+
+    SECTION("metavar for multi options work")
+    {
+        nitro::broken_options::parser parser("app_name", "about");
+
+        std::stringstream s;
+
+
+        parser.multi_option("mopt", "some multi opt").metavar("test");
+
+        parser.usage(s);
+
+        REQUIRE(
+            s.str() ==
+            R"EXPECTED(usage: app_name --mopt
+
+about
+
+arguments:
+    --mopt test                           some multi opt
+)EXPECTED");
+    }
+
 }

--- a/tests/broken_options_test.cpp
+++ b/tests/broken_options_test.cpp
@@ -1001,7 +1001,7 @@ arguments:
 about
 
 arguments:
-    --mopt test                           some multi opt
+  --mopt test                             some multi opt
 )EXPECTED");
     }
 

--- a/tests/broken_options_test.cpp
+++ b/tests/broken_options_test.cpp
@@ -959,7 +959,7 @@ TEST_CASE("Reading the value from the ENV variables", "[broken_options]")
         CHECK(options.get("opt4", 0) == "foo");
     }
 }
-TEST_CASE("Usage arg_name work")
+TEST_CASE("Usage metavar work")
 {
     SECTION("arg_name for options work")
     {
@@ -968,7 +968,7 @@ TEST_CASE("Usage arg_name work")
         std::stringstream s;
 
 
-        parser.option("opt_nosd", "some opt without short and default").arg_name("test");
+        parser.option("opt_nosd", "some opt without short and default").metavar("test");
 
         parser.usage(s);
 

--- a/tests/broken_options_test.cpp
+++ b/tests/broken_options_test.cpp
@@ -1009,6 +1009,7 @@ TEST_CASE("parsing toggles with prefix and default value")
     {
         nitro::broken_options::argument arg("--no-arg");
         REQUIRE(arg.has_prefix());
+        REQUIRE(arg.prefix() == "no");
         REQUIRE(arg.name_without_prefix() == "arg");
     }
 
@@ -1136,5 +1137,39 @@ TEST_CASE("parsing toggles with prefix and default value")
         REQUIRE(named_arg.name() == "--no-ab");
         REQUIRE(named_arg.name_without_prefix() == "ab");
         REQUIRE(named_arg.data() == "--no-ab=5");
+    }
+    SECTION("setting a prefix")
+    {
+        nitro::broken_options::argument arg("--without-arg");
+        REQUIRE(arg.has_prefix());
+        REQUIRE(arg.name() == "--without-arg");
+        REQUIRE(arg.name_without_prefix() == "arg");
+        REQUIRE(arg.prefix() == "without");
+    }
+    SECTION("test argument with negativ prefix")
+    {
+        int argc = 2;
+        const char* argv[] = { "", "--without-arg" };
+
+        nitro::broken_options::parser parser;
+
+        parser.toggle("arg");
+
+        auto options = parser.parse(argc, argv);
+
+        REQUIRE(!options.given("arg"));
+    }
+    SECTION("test argument with positiv prefix")
+    {
+        int argc = 2;
+        const char* argv[] = { "", "--yes-arg" };
+
+        nitro::broken_options::parser parser;
+
+        parser.toggle("arg");
+
+        auto options = parser.parse(argc, argv);
+
+        REQUIRE(options.given("arg"));
     }
 }

--- a/tests/broken_options_test.cpp
+++ b/tests/broken_options_test.cpp
@@ -967,14 +967,12 @@ TEST_CASE("Usage metavar work")
 
         std::stringstream s;
 
-
         parser.option("opt_nosd", "some opt without short and default").metavar("test");
 
         parser.usage(s);
 
-        REQUIRE(
-            s.str() ==
-            R"EXPECTED(usage: app_name --opt_nosd
+        REQUIRE(s.str() ==
+                R"EXPECTED(usage: app_name --opt_nosd
 
 about
 
@@ -989,14 +987,12 @@ arguments:
 
         std::stringstream s;
 
-
         parser.multi_option("mopt", "some multi opt").metavar("test");
 
         parser.usage(s);
 
-        REQUIRE(
-            s.str() ==
-            R"EXPECTED(usage: app_name --mopt
+        REQUIRE(s.str() ==
+                R"EXPECTED(usage: app_name --mopt
 
 about
 
@@ -1004,5 +1000,4 @@ arguments:
   --mopt test                             some multi opt
 )EXPECTED");
     }
-
 }

--- a/tests/broken_options_test.cpp
+++ b/tests/broken_options_test.cpp
@@ -961,7 +961,7 @@ TEST_CASE("Reading the value from the ENV variables", "[broken_options]")
 }
 TEST_CASE("Usage metavar work")
 {
-    SECTION("arg_name for options work")
+    SECTION("metavar for options work")
     {
         nitro::broken_options::parser parser("app_name", "about");
 

--- a/tests/broken_options_test.cpp
+++ b/tests/broken_options_test.cpp
@@ -959,3 +959,27 @@ TEST_CASE("Reading the value from the ENV variables", "[broken_options]")
         CHECK(options.get("opt4", 0) == "foo");
     }
 }
+TEST_CASE("Usage arg_name work")
+{
+    SECTION("arg_name for options work")
+    {
+        nitro::broken_options::parser parser("app_name", "about");
+
+        std::stringstream s;
+
+
+        parser.option("opt_nosd", "some opt without short and default").arg_name("test");
+
+        parser.usage(s);
+
+        REQUIRE(
+            s.str() ==
+            R"EXPECTED(usage: app_name --opt_nosd
+
+about
+
+arguments:
+  --opt_nosd test                         some opt without short and default
+)EXPECTED");
+    }
+}


### PR DESCRIPTION
The prefix can be set for the true and false option, which allow creating a toggle with the name foo and setting the prefix to with and without. Therefore the generated argument names become --with-foo and --without-foo.

- add prefix_ value in argument.hpp
- some little changes in has_prefix(), name_without_prefix()
- add regex