### PR TITLE
fix(options): include header that defines numeric_limits

### DIFF
--- a/include/nitro/options/parser.hpp
+++ b/include/nitro/options/parser.hpp
@@ -39,6 +39,7 @@
 
 #include <deque>
 #include <iostream>
+#include <limits>
 #include <map>
 #include <string>
 #include <vector>


### PR DESCRIPTION
clang apparently needs this