### PR TITLE
Bump cmake_required_version to 3.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,7 +45,7 @@ if(TARGET Nitro::nitro)
     endif()
 else()
 
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.10)
 
 project(Nitro VERSION 1.0.0)
 


### PR DESCRIPTION
Otherwise it fails to run the cmake script because support for CMake versions <3.5 has been removed.