### PR TITLE
feat(options): add get_all_option_names()

### DIFF
--- a/include/nitro/options/parser.hpp
+++ b/include/nitro/options/parser.hpp
@@ -79,6 +79,28 @@ namespace options
     public:
         std::ostream& usage(std::ostream& s = std::cout);
 
+        std::set<std::string> get_all_option_names() const
+        {
+            std::set<std::string> res;
+
+            for (const auto& option : get_all_options())
+            {
+                res.emplace(option.first);
+            }
+
+            for (const auto& multi_option : get_all_multi_options())
+            {
+                res.emplace(multi_option.first);
+            }
+
+            for (const auto& toggle : get_all_toggles())
+            {
+                res.emplace(toggle.first);
+            }
+
+            return res;
+        }
+
     private:
         void check_parser_consistency();
 

--- a/tests/options_test.cpp
+++ b/tests/options_test.cpp
@@ -685,6 +685,23 @@ TEST_CASE("Simple named arguments can get parsed from command line", "[options]"
     }
 }
 
+TEST_CASE("get_all_option_names() returns all declared options")
+{
+    nitro::options::parser parser;
+
+    parser.option("opt1");
+    parser.multi_option("opt2");
+    parser.multi_option("opt3");
+    parser.option("opt4");
+
+    auto names = parser.get_all_option_names();
+    REQUIRE(names.size() == 4);
+    REQUIRE(names.count("opt1") == 1);
+    REQUIRE(names.count("opt2") == 1);
+    REQUIRE(names.count("opt3") == 1);
+    REQUIRE(names.count("opt4") == 1);
+}
+
 TEST_CASE("Short-cut arguments can get parsed from command line", "[options]")
 {
     SECTION("Simple string short named values work")


### PR DESCRIPTION
Like it says on the tin, this gives you all the names of all the defined options in this parser.