### PR TITLE
fix(options): throw if provided is called with non-existant option.

### DIFF
--- a/include/nitro/options/arguments.hpp
+++ b/include/nitro/options/arguments.hpp
@@ -185,6 +185,13 @@ namespace options
 
         bool provided(const std::string& name) const
         {
+            if (options_.count(name) == 0 && multi_options_.count(name) == 0 &&
+                toggles_.count(name) == 0)
+            {
+                throw no_such_argument_error("Can not get if --", name,
+                                             " was provided: No such option exists!");
+            }
+
             return provided_.count(name);
         }
 

--- a/tests/options_test.cpp
+++ b/tests/options_test.cpp
@@ -578,6 +578,7 @@ TEST_CASE("Getting non-existent argument throws correctly")
     REQUIRE_THROWS_AS(options.get("test", 0), nitro::options::no_such_argument_error);
     REQUIRE_THROWS_AS(options.get_all("test"), nitro::options::no_such_argument_error);
     REQUIRE_THROWS_AS(options.get(42), nitro::options::no_such_argument_error);
+    REQUIRE_THROWS_AS(options.provided("test"), nitro::options::no_such_argument_error);
 }
 
 TEST_CASE("Simple named arguments can get parsed from command line", "[options]")


### PR DESCRIPTION
This fixes #44